### PR TITLE
AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+build: off
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal test

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -46,9 +46,10 @@ executable hackage-repo-tool
                        optparse-applicative >= 0.11 && < 0.15,
                        tar                  >= 0.4  && < 0.6,
                        time                 >= 1.2  && < 1.9,
-                       unix                 >= 2.5  && < 2.8,
                        zlib                 >= 0.5  && < 0.7,
                        hackage-security     >= 0.5  && < 0.6
+  if !os(windows)
+    build-depends: unix >= 2.5  && < 2.8
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  DeriveDataTypeable

--- a/hackage-repo-tool/src/Hackage/Security/RepoTool/Util/IO.hs
+++ b/hackage-repo-tool/src/Hackage/Security/RepoTool/Util/IO.hs
@@ -12,16 +12,13 @@ module Hackage.Security.RepoTool.Util.IO (
 
 import Control.Exception
 import Data.Typeable
+import Data.Time.Clock.POSIX
 import System.IO.Error
+import qualified System.Directory as Directory
 import qualified Codec.Archive.Tar       as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
 import qualified Codec.Compression.GZip  as GZip
 import qualified Data.ByteString.Lazy    as BS.L
-
--- Unlike the hackage-security library properly,
--- this currently works on unix systems only
-import System.Posix.Types (EpochTime)
-import qualified System.Posix.Files as Posix
 
 -- hackage-security
 import Hackage.Security.Util.Path
@@ -31,13 +28,23 @@ import Hackage.Security.RepoTool.Options
 import Hackage.Security.RepoTool.Layout
 import Hackage.Security.RepoTool.Paths
 
+import System.Posix.Types (EpochTime)
+#ifndef mingw32_HOST_OS
+import qualified System.Posix.Files as Posix
+#endif
+
 -- | Get the modification time of the specified file
 --
 -- Returns 0 if the file does not exist .
 getFileModTime :: GlobalOpts -> RepoLoc -> TargetPath' -> IO EpochTime
 getFileModTime opts repoLoc targetPath =
     handle handler $
-      Posix.modificationTime <$> Posix.getFileStatus (toFilePath fp)
+      -- Underlying implementation of 'Directory.getModificationTime' converts
+      -- from POSIX seconds, so there shouldn't be loss of precision.
+      -- NB: Apparently, this has low clock resolution on GHC < 7.8.
+      -- I don't think we care.
+      fromInteger . floor . utcTimeToPOSIXSeconds
+        <$> Directory.getModificationTime (toFilePath fp)
   where
     fp :: Path Absolute
     fp = anchorTargetPath' opts repoLoc targetPath
@@ -62,10 +69,16 @@ createSymbolicLink :: (FsRoot root, FsRoot root')
                    -> Path root' -- ^ Link location
                    -> IO ()
 createSymbolicLink linkTarget linkLoc = do
+#ifndef mingw32_HOST_OS
     createDirectoryIfMissing True (takeDirectory linkLoc)
     linkTarget' <- toAbsoluteFilePath linkTarget
     linkLoc'    <- toAbsoluteFilePath linkLoc
     Posix.createSymbolicLink linkTarget' linkLoc'
+#else
+    error $ "Cannot create symbolic links on Windows"
+  where
+    _ = (linkTarget, linkLoc) -- -Wall suppression
+#endif
 
 {-------------------------------------------------------------------------------
   Working with tar archives


### PR DESCRIPTION
This includes the changes from #176 (CC @ezyang), rebased against master, and adds in an AppVeyor configuration as requested in #176. I've checked that the AppVeyor configuration works (see https://ci.appveyor.com/project/snoyberg/hackage-security/build/1.0.1), but someone will need to enable AppVeyor for haskell/hackage-security to make this work.