### PR TITLE
Allow QuickCheck-2.11

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -237,7 +237,10 @@ test-suite TestSuite
   build-depends:       tasty            == 1.0.*,
                        tasty-hunit      == 0.10.*,
                        tasty-quickcheck == 0.10.*,
-                       QuickCheck       == 2.9.*,
+                       QuickCheck       == 2.11.*,
+                       aeson            == 1.3.*,
+                       vector           == 0.12.*,
+                       unordered-containers >=0.2.8.0 && <0.3,
                        temporary        == 1.2.*
 
   hs-source-dirs:      tests

--- a/hackage-security/tests/TestSuite.hs
+++ b/hackage-security/tests/TestSuite.hs
@@ -70,6 +70,7 @@ tests = testGroup "hackage-security" [
           testProperty "prop_roundtrip_canonical" JSON.prop_roundtrip_canonical
         , testProperty "prop_roundtrip_pretty"    JSON.prop_roundtrip_pretty
         , testProperty "prop_canonical_pretty"    JSON.prop_canonical_pretty
+        , testProperty "prop_aeson_canonical"     JSON.prop_aeson_canonical
         ]
   ]
 


### PR DESCRIPTION
Canonical JSON and RFC 7159 still don't agree, even strings are ASCII, as per RFC newlines have to be escaped.

Related comment is https://github.com/theupdateframework/tuf/issues/457#issuecomment-307143201

Yet, e.g. `aeson` lenienly accepts `\x0a`, but doesn't produce it:

```haskell
λ Text.JSON.Canonical> prettyCanonicalJSON (JSString "\n")
"\"\n\""
λ Data.Aeson> decode "\"\n\"" :: Maybe String
Just "\n"
λ Data.Aeson> encode (decode "\"n\"" :: Maybe String)
"\"\\n\""
```

I'm tempted to restrict `hackage-security` to only allow characters in `0x20-0x7f` range. That's enough for  our use, isn't it?