### PR TITLE
Bump network and aeson.

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -43,6 +43,6 @@ executable example-client
   -- see comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.7
+                   network     >= 2.6 && < 2.8
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -69,7 +69,7 @@ executable hackage-repo-tool
   -- see comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.7
+                   network     >= 2.6 && < 2.8
   else
     build-depends: network     >= 2.5 && < 2.6
 

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -49,6 +49,6 @@ library
   -- See comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.7
+                   network     >= 2.6 && < 2.8
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -28,6 +28,6 @@ library
   -- See comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.7
+                   network     >= 2.6 && < 2.8
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -34,6 +34,6 @@ library
   -- see comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.7
+                   network     >= 2.6 && < 2.8
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+* Allow `network-2.7.0.0`
+* Allow `aeson-1.4.0.0`
+
 0.5.3.0
 -------
 

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -200,7 +200,7 @@ library
   -- dependency in network is not redundant.)
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.7
+                   network     >= 2.6 && < 2.8
   else
     build-depends: network     >= 2.5 && < 2.6
 
@@ -238,7 +238,7 @@ test-suite TestSuite
                        tasty-hunit      == 0.10.*,
                        tasty-quickcheck == 0.10.*,
                        QuickCheck       == 2.11.*,
-                       aeson            == 1.3.*,
+                       aeson            == 1.4.*,
                        vector           == 0.12.*,
                        unordered-containers >=0.2.8.0 && <0.3,
                        temporary        == 1.2.*


### PR DESCRIPTION
The only breaking change in network-2.7 is in `sendFd`, which is not used by `hackage-security`.