### PR TITLE
hackage-repo-tool: Fix a compile warning.

### DIFF
--- a/hackage-repo-tool/src/Main.hs
+++ b/hackage-repo-tool/src/Main.hs
@@ -494,7 +494,7 @@ data WhenWrite =
 -- version number) we don't overwrite it and return Nothing; otherwise we
 -- increment the version number, write the file, and (if it's in the index)
 -- copy it to the unpacked index directory.
-updateFile :: forall a. (ToJSON WriteJSON (Signed a), HasHeader a)
+updateFile :: forall a. (ToJSON WriteJSON a, HasHeader a)
            => GlobalOpts
            -> RepoLoc
            -> WhenWrite


### PR DESCRIPTION
The warning was:

    • The constraint ‘ToJSON WriteJSON (Signed a)’
        matches an instance declaration
      instance (Monad m, ToJSON m a) => ToJSON m (Signed a)
        -- Defined in ‘hackage-security-0.5.3.0:Hackage.Security.TUF.Signed’
      This makes type inference for inner bindings fragile;
        either use MonoLocalBinds, or simplify it using the instance

Fixed by simplifying using the instance.