### PR TITLE
Bump the constraint on time

### DIFF
--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -54,7 +54,7 @@ executable hackage-repo-tool
                        filepath             >= 1.2  && < 1.5,
                        optparse-applicative >= 0.11 && < 0.15,
                        tar                  >= 0.4  && < 0.6,
-                       time                 >= 1.2  && < 1.9,
+                       time                 >= 1.2  && < 1.10,
                        zlib                 >= 0.5  && < 0.7,
                        hackage-security     >= 0.5  && < 0.6
   if !os(windows)

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -113,7 +113,7 @@ library
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
                        -- functionality, 0.5.0 changes type of serialise
                        tar               >= 0.5     && < 0.6,
-                       time              >= 1.2     && < 1.9,
+                       time              >= 1.2     && < 1.10,
                        transformers      >= 0.4     && < 0.6,
                        zlib              >= 0.5     && < 0.7,
                        -- whatever versions are bundled with ghc:


### PR DESCRIPTION
Encounter this when trying to build `cabal-install` using `ghc` HEAD where `time` was bumped to `1.9.2`.