### PR TITLE
Allow building with network-3.1.0.0.

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -45,6 +45,6 @@ executable example-client
   -- see comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.1
+                   network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -74,7 +74,7 @@ executable hackage-repo-tool
   -- see comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.1
+                   network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6
 

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -51,6 +51,6 @@ library
   -- See comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.1
+                   network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -34,6 +34,6 @@ library
   -- See comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.1
+                   network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -39,6 +39,6 @@ library
   -- see comments in hackage-security.cabal
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.1
+                   network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,7 +1,7 @@
 unreleased
 ----------
 
-* Allow `network-3.0.0.0`
+* Allow `network-3.1.0.0`
 * Allow `aeson-1.4.0.0`
 
 0.5.3.0

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -214,7 +214,7 @@ library
   -- dependency in network is not redundant.)
   if flag(use-network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.1
+                   network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6
 


### PR DESCRIPTION
Main change in 3.1.0.0 [seems to be the deprecation of `fdSocket`](http://hackage.haskell.org/package/network-3.1.0.0/changelog), which we don't use.