### PR TITLE
Report missing .meta keys as SchemaErrors

### DIFF
--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -61,7 +61,7 @@ executable hackage-repo-tool
                        tar                  >= 0.4  && < 0.6,
                        time                 >= 1.2  && < 1.10,
                        zlib                 >= 0.5  && < 0.7,
-                       hackage-security     >= 0.5  && < 0.6
+                       hackage-security     >= 0.5  && < 0.7
   if !os(windows)
     build-depends:     unix                 >= 2.5  && < 2.8
 

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -30,7 +30,7 @@ executable hackage-root-tool
   build-depends:       base                 >= 4.4  && < 5,
                        filepath             >= 1.2  && < 1.5,
                        optparse-applicative >= 0.11 && < 0.15,
-                       hackage-security     >= 0.5  && < 0.6
+                       hackage-security     >= 0.5  && < 0.7
   default-language:    Haskell2010
   other-extensions:    CPP, ScopedTypeVariables, RecordWildCards
   ghc-options:         -Wall

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -36,7 +36,7 @@ library
                        HTTP             >= 4000.2.19 && < 4000.4,
                        mtl              >= 2.1       && < 2.3,
                        zlib             >= 0.5       && < 0.7,
-                       hackage-security >= 0.5       && < 0.6
+                       hackage-security >= 0.5       && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  DeriveDataTypeable

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -27,7 +27,7 @@ library
                        data-default-class >= 0.0,
                        http-client        >= 0.4 && < 0.6,
                        http-types         >= 0.8,
-                       hackage-security   >= 0.5 && < 0.6
+                       hackage-security   >= 0.5 && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  FlexibleContexts

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,8 +1,12 @@
-unreleased
-----------
+See also http://pvp.haskell.org/faq
 
-* Allow `network-3.1.0.0`
-* Allow `aeson-1.4.0.0`
+0.6.0.0
+-------
+
+* Remove `Hackage.Security.TUF.FileMap.lookupM`
+* Report missing keys in `.meta` objects more appropriately as
+  `ReportSchemaErrors(expected)` instead of via `Monad(fail)`
+* Add support for GHC 8.8 / base-4.13
 
 0.5.3.0
 -------

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                hackage-security
-version:             0.5.3.0
+version:             0.6.0.0
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -106,11 +106,12 @@ library
                        Hackage.Security.Util.TypedEmbedded
                        Prelude
   -- We support ghc 7.4 (bundled with Cabal 1.14) and up
-  build-depends:       base              >= 4.5     && < 4.13,
+  build-depends:       base              >= 4.5     && < 4.14,
                        base16-bytestring >= 0.1.1   && < 0.2,
                        base64-bytestring >= 1.0     && < 1.1,
                        bytestring        >= 0.9     && < 0.11,
-                       Cabal             >= 1.14    && < 2.6,
+                       Cabal             >= 1.14    && < 2.6
+                                      || >= 3.0     && < 3.2,
                        containers        >= 0.4     && < 0.7,
                        ed25519           >= 0.0     && < 0.1,
                        filepath          >= 1.2     && < 1.5,

--- a/hackage-security/src/Hackage/Security/TUF/FileMap.hs
+++ b/hackage-security/src/Hackage/Security/TUF/FileMap.hs
@@ -13,8 +13,6 @@ module Hackage.Security.TUF.FileMap (
   , (!)
   , insert
   , fromList
-    -- * Convenience accessors
-  , lookupM
     -- * Comparing file maps
   , FileChange(..)
   , fileMapChanges
@@ -70,16 +68,6 @@ insert fp nfo = FileMap . Map.insert fp nfo . fileMap
 
 fromList :: [(TargetPath, FileInfo)] -> FileMap
 fromList = FileMap . Map.fromList
-
-{-------------------------------------------------------------------------------
-  Convenience accessors
--------------------------------------------------------------------------------}
-
-lookupM :: Monad m => FileMap -> TargetPath -> m FileInfo
-lookupM m fp =
-    case lookup fp m of
-      Nothing  -> fail $ "No entry for " ++ pretty fp ++ " in filemap"
-      Just nfo -> return nfo
 
 {-------------------------------------------------------------------------------
   Comparing filemaps

--- a/hackage-security/src/Hackage/Security/TUF/Snapshot.hs
+++ b/hackage-security/src/Hackage/Security/TUF/Snapshot.hs
@@ -13,6 +13,7 @@ import Hackage.Security.TUF.FileMap
 import Hackage.Security.TUF.Layout.Repo
 import Hackage.Security.TUF.Signed
 import qualified Hackage.Security.TUF.FileMap as FileMap
+import Hackage.Security.Util.Pretty (pretty)
 
 {-------------------------------------------------------------------------------
   Datatypes
@@ -76,9 +77,12 @@ instance ( MonadReader RepoLayout m
     snapshotVersion     <- fromJSField enc "version"
     snapshotExpires     <- fromJSField enc "expires"
     snapshotMeta        <- fromJSField enc "meta"
-    snapshotInfoRoot    <- FileMap.lookupM snapshotMeta (pathRoot       repoLayout)
-    snapshotInfoMirrors <- FileMap.lookupM snapshotMeta (pathMirrors    repoLayout)
-    snapshotInfoTarGz   <- FileMap.lookupM snapshotMeta (pathIndexTarGz repoLayout)
+    let lookupMeta k = case FileMap.lookup k snapshotMeta of
+          Nothing -> expected ("\"" ++ pretty k ++ "\" entry in .meta object") Nothing
+          Just v  -> pure v
+    snapshotInfoRoot    <- lookupMeta (pathRoot       repoLayout)
+    snapshotInfoMirrors <- lookupMeta (pathMirrors    repoLayout)
+    snapshotInfoTarGz   <- lookupMeta (pathIndexTarGz repoLayout)
     let snapshotInfoTar = FileMap.lookup (pathIndexTar repoLayout) snapshotMeta
     return Snapshot{..}
 

--- a/hackage-security/src/Hackage/Security/TUF/Timestamp.hs
+++ b/hackage-security/src/Hackage/Security/TUF/Timestamp.hs
@@ -13,6 +13,7 @@ import Hackage.Security.TUF.Header
 import Hackage.Security.TUF.Layout.Repo
 import Hackage.Security.TUF.Signed
 import qualified Hackage.Security.TUF.FileMap as FileMap
+import Hackage.Security.Util.Pretty (pretty)
 
 {-------------------------------------------------------------------------------
   Datatypes
@@ -56,7 +57,10 @@ instance ( MonadReader RepoLayout m
     timestampVersion      <- fromJSField enc "version"
     timestampExpires      <- fromJSField enc "expires"
     timestampMeta         <- fromJSField enc "meta"
-    timestampInfoSnapshot <- FileMap.lookupM timestampMeta (pathSnapshot repoLayout)
+    let lookupMeta k = case FileMap.lookup k timestampMeta of
+          Nothing -> expected ("\"" ++ pretty k ++ "\" entry in .meta object") Nothing
+          Just v  -> pure v
+    timestampInfoSnapshot <- lookupMeta (pathSnapshot repoLayout)
     return Timestamp{..}
 
 instance (MonadKeys m, MonadReader RepoLayout m) => FromJSON m (Signed Timestamp) where


### PR DESCRIPTION
This change was triggered by trying make the codebase MonadFail
compatible which exposed a `lookupM` convenience wrapper which
reported lookup failures via Monad(fail). However, schema errors
such as missing keys or similar are supposed to be reported via
the `ReportSchemaError(expected)` mechanism.

This however prompts a major version increment to 0.6.0.0.

So this fixes two issues with one commit.