### PR TITLE
Relax some package upper bounds

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -21,7 +21,7 @@ executable example-client
   main-is:             Main.hs
   other-modules: Prelude ExampleClient.Options
 
-  build-depends:       base                 >= 4.5 && < 4.13,
+  build-depends:       base                 >= 4.5 && < 4.14,
                        bytestring           >= 0.9,
                        Cabal                >= 1.12,
                        directory            >= 1.1,

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -53,11 +53,11 @@ executable hackage-repo-tool
                        Prelude
 
   build-depends:       base                 >= 4.5  && < 5,
-                       Cabal                >= 1.14 && < 2.6,
+                       Cabal                >= 1.14 && < 3.1,
                        bytestring           >= 0.9  && < 0.11,
                        directory            >= 1.1  && < 1.4,
                        filepath             >= 1.2  && < 1.5,
-                       optparse-applicative >= 0.11 && < 0.15,
+                       optparse-applicative >= 0.11 && < 0.16,
                        tar                  >= 0.4  && < 0.6,
                        time                 >= 1.2  && < 1.10,
                        zlib                 >= 0.5  && < 0.7,

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -29,7 +29,7 @@ executable hackage-root-tool
   main-is:             Main.hs
   build-depends:       base                 >= 4.4  && < 5,
                        filepath             >= 1.2  && < 1.5,
-                       optparse-applicative >= 0.11 && < 0.15,
+                       optparse-applicative >= 0.11 && < 0.16,
                        hackage-security     >= 0.5  && < 0.7
   default-language:    Haskell2010
   other-extensions:    CPP, ScopedTypeVariables, RecordWildCards

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -23,7 +23,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
-  build-depends:       base        >= 4.5 && < 4.13,
+  build-depends:       base        >= 4.5 && < 4.14,
                        bytestring  >= 0.9,
                        process     >= 1.1,
                        hackage-security

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -252,11 +252,11 @@ test-suite TestSuite
   build-depends:       tasty            == 1.2.*,
                        tasty-hunit      == 0.10.*,
                        tasty-quickcheck == 0.10.*,
-                       QuickCheck       == 2.11.*,
+                       QuickCheck       >= 2.11 && <2.14,
                        aeson            == 1.4.*,
                        vector           == 0.12.*,
                        unordered-containers >=0.2.8.0 && <0.3,
-                       temporary        == 1.2.*
+                       temporary        >= 1.2 && < 1.4
 
   hs-source-dirs:      tests
   default-language:    Haskell2010


### PR DESCRIPTION
I tested this with the following `cabal.project` file:

```
packages: hackage-security
          hackage-security-curl
          hackage-root-tool
          hackage-repo-tool
          hackage-security-HTTP

package hackage-security
  tests: true

allow-newer:
  aeson:time
  aeson:template-haskell
```

Several bounds (particularly on `base`) can be relaxed safely. 