### PR TITLE
Allow http-client-0.6

### DIFF
--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -25,7 +25,7 @@ library
   build-depends:       base               >= 4.5 && < 4.14,
                        bytestring         >= 0.9,
                        data-default-class >= 0.0,
-                       http-client        >= 0.4 && < 0.6,
+                       http-client        >= 0.4 && < 0.7,
                        http-types         >= 0.8,
                        hackage-security   >= 0.5 && < 0.7
   hs-source-dirs:      src


### PR DESCRIPTION
The breaking change was in `renderParts`, which is not used.