### PR TITLE
Add support for logging cache locking events

### DIFF
--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -5,11 +5,13 @@ See also http://pvp.haskell.org/faq
 
 * Remove `Hackage.Security.TUF.FileMap.lookupM`
 * Don't expose `Hackage.Security.Util.IO` module
+* Don't expose `Hackage.Security.Util.Lens` module
 * Report missing keys in `.meta` objects more appropriately as
   `ReportSchemaErrors(expected)` instead of via `Monad(fail)`
 * Add support for GHC 8.8 / base-4.13
 * Use `lukko` for file-locking
-* Don't expose `Hackage.Security.Util.Lens` module
+* Extend `LogMessage` to signal events for cache lock acquiring and release
+* New `lockCacheWithLogger` operation
 
 0.5.3.0
 -------

--- a/hackage-security/src/Hackage/Security/Client/Repository.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository.hs
@@ -316,6 +316,27 @@ data LogMessage =
     -- (we will try with a different mirror if any are available)
   | LogMirrorFailed MirrorDescription SomeException
 
+    -- | This log event is triggered before invoking a filesystem lock
+    -- operation that may block for a significant amount of time; once
+    -- the possibly blocking call completes successfully,
+    -- 'LogLockWaitDone' will be emitted.
+    --
+    -- @since 0.6.0
+  | LogLockWait (Path Absolute)
+
+    -- | Denotes completion of the operation that advertised a
+    -- 'LogLockWait' event
+    --
+    -- @since 0.6.0
+  | LogLockWaitDone (Path Absolute)
+
+    -- | Denotes the filesystem lock previously acquired (signaled by
+    -- 'LogLockWait') has been released.
+    --
+    -- @since 0.6.0
+  | LogUnlock (Path Absolute)
+
+
 -- | Records why we are downloading a file rather than updating it.
 data UpdateFailure =
     -- | Server does not support incremental downloads
@@ -451,6 +472,12 @@ instance Pretty LogMessage where
       "Cannot update " ++ pretty file ++ " (" ++ pretty ex ++ ")"
   pretty (LogMirrorFailed mirror ex) =
       "Exception " ++ displayException ex ++ " when using mirror " ++ mirror
+  pretty (LogLockWait file) =
+      "Waiting to acquire cache lock on " ++ pretty file
+  pretty (LogLockWaitDone file) =
+      "Acquired cache lock on " ++ pretty file
+  pretty (LogUnlock file) =
+      "Released cache lock on " ++ pretty file
 
 instance Pretty UpdateFailure where
   pretty UpdateImpossibleUnsupported =

--- a/hackage-security/src/Hackage/Security/Client/Repository/Local.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/Local.hs
@@ -51,7 +51,7 @@ withRepository repo
     , repClearCache    = clearCache    cache
     , repWithIndex     = withIndex     cache
     , repGetIndexIdx   = getIndexIdx   cache
-    , repLockCache     = lockCache     cache
+    , repLockCache     = lockCacheWithLogger logger cache
     , repWithMirror    = mirrorsUnsupported
     , repLog           = logger
     , repLayout        = repLayout

--- a/hackage-security/src/Hackage/Security/Client/Repository/Remote.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/Remote.hs
@@ -178,7 +178,7 @@ withRepository httpLib
       , repClearCache    = Cache.clearCache    cache
       , repWithIndex     = Cache.withIndex     cache
       , repGetIndexIdx   = Cache.getIndexIdx   cache
-      , repLockCache     = Cache.lockCache     cache
+      , repLockCache     = Cache.lockCacheWithLogger logger cache
       , repWithMirror    = withMirror httpLib
                                       selectedMirror
                                       logger


### PR DESCRIPTION
Since we can now block for indefinite amount of time if we can't get
the cache lock it's useful to have some sort of logging output to
diagnose a stuck lock more easily if this ever occurs; moreover in
combination with `-vverbose+timestamp` it allows us to see when and
for how long the repo cache lock is held during cabal operations which
is also quite useful information to have.

This extends the `LogMessage` type with additional constructors to
allow to encode events for cache lock acquiring and release, and adds
a call-back to the (non-public) `withDirLock` for emitting the
respective events; A new (public) `lockCacheWithLogger` function is
added which makes use of this new `withDirLock` callback.