### PR TITLE
add alternative Ed25519 switching

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -63,6 +63,11 @@ flag lukko
   manual:      True
   default:     True
 
+flag use-eccrypto
+  description: Use pure Haskell cryptographic signing
+  manual:      False
+  default:     False
+
 library
   -- Most functionality is exported through the top-level entry points .Client
   -- and .Server; the other exported modules are intended for qualified imports.
@@ -118,7 +123,6 @@ library
                                       || >= 2.0     && < 2.6
                                       || >= 3.0     && < 3.2,
                        containers        >= 0.4     && < 0.7,
-                       ed25519           >= 0.0     && < 0.1,
                        filepath          >= 1.2     && < 1.5,
                        parsec            >= 3.1     && < 3.2,
                        pretty            >= 1.0     && < 1.2,
@@ -132,6 +136,10 @@ library
                        -- whatever versions are bundled with ghc:
                        template-haskell,
                        ghc-prim
+  if flag(use-eccrypto)
+      build-depends:   eccrypto-ed25519-bindings >= 0.1.2     && < 0.2
+  else
+      build-depends:   ed25519           >= 0.0     && < 0.1
   if flag(old-directory)
     build-depends:     directory  >= 1.1.0.2 && < 1.2,
                        old-time   >= 1 &&       < 1.2

--- a/hackage-security/src/Hackage/Security/Key.hs
+++ b/hackage-security/src/Hackage/Security/Key.hs
@@ -183,20 +183,28 @@ sign :: PrivateKey typ -> BS.L.ByteString -> BS.ByteString
 sign (PrivateKeyEd25519 pri) =
     Ed25519.unSignature . dsign pri . BS.concat . BS.L.toChunks
   where
+#ifdef MIN_VERSION_ed25519
 #if MIN_VERSION_ed25519(0,0,4)
     dsign = Ed25519.dsign
 #else
     dsign = Ed25519.sign'
+#endif
+#else
+    dsign = Ed25519.dsign
 #endif
 
 verify :: PublicKey typ -> BS.L.ByteString -> BS.ByteString -> Bool
 verify (PublicKeyEd25519 pub) inp sig =
     dverify pub (BS.concat $ BS.L.toChunks inp) (Ed25519.Signature sig)
   where
+#ifdef MIN_VERSION_ed25519
 #if MIN_VERSION_ed25519(0,0,4)
     dverify = Ed25519.dverify
 #else
     dverify = Ed25519.verify'
+#endif
+#else
+    dverify = Ed25519.dverify
 #endif
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
As discussed with Mikhail last year on cabal-devel, I now would like to present a minimal patch to enable pure(r) Haskell cryptographic signatures. He expressed possible acceptance of a default-off compile-time option, which is herein included with minimal needed changes elsewhere. The new dependency provides almost the same API as the currently default ed25519 package, but uses another library underneath.
I have adressed some prior complaints to my optional dependency:
My library is now much smaller in dependency footprint. It is also undergoing academic review. Better documentation is still missing, though.