### PR TITLE
Fix bug in-non-lukko locking

### DIFF
--- a/hackage-security/src/Hackage/Security/Util/IO.hs
+++ b/hackage-security/src/Hackage/Security/Util/IO.hs
@@ -141,10 +141,10 @@ withDirLock logger dir
             (me++"cannot remove lock file before directory lock fallback")
 
     releaseLock (Just h) =
-        hClose h
 #if MIN_VERSION_base(4,11,0)
-        >> hUnlock h
+        hUnlock h >>
 #endif
+        hClose h
     releaseLock Nothing  = removeDirectory lock
 #endif
 


### PR DESCRIPTION
The invalid ordering cause https://github.com/haskell/cabal/issues/6657

```
cabal update
Downloading the latest package list from hackage.haskell.org
flock: invalid argument (Bad file descriptor)
```

error came from `hUnlock` function, trying to unlock closed file.