### PR TITLE
Support basic auth

### DIFF
--- a/hackage-security-HTTP/src/Hackage/Security/Client/Repository/HttpLib/HTTP.hs
+++ b/hackage-security-HTTP/src/Hackage/Security/Client/Repository/HttpLib/HTTP.hs
@@ -62,7 +62,7 @@ get :: Throws SomeRemoteError
     -> IO a
 get browser reqHeaders uri callback = wrapCustomEx $ do
     response <- request browser
-      $ setRequestHeaders reqHeaders
+      $ addRequestHeaders reqHeaders
       -- avoid silly `Content-Length: 0` header inserted by `mkRequest`
       $ removeHeader HTTP.HdrContentLength
       $ HTTP.mkRequest HTTP.GET uri
@@ -78,7 +78,7 @@ getRange :: Throws SomeRemoteError
 getRange browser reqHeaders uri (from, to) callback = wrapCustomEx $ do
     response <- request browser
       $ setRange from to
-      $ setRequestHeaders reqHeaders
+      $ addRequestHeaders reqHeaders
       -- avoid silly `Content-Length: 0` header inserted by `mkRequest`
       $ removeHeader HTTP.HdrContentLength
       $ HTTP.mkRequest HTTP.GET uri
@@ -234,8 +234,8 @@ setRange from to = HTTP.insertHeader HTTP.HdrRange rangeHeader
     -- See <http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html>
     rangeHeader = "bytes=" ++ show from ++ "-" ++ show (to - 1)
 
-setRequestHeaders :: HTTP.HasHeaders a => [HttpRequestHeader] -> a -> a
-setRequestHeaders =
+addRequestHeaders :: HTTP.HasHeaders a => [HttpRequestHeader] -> a -> a
+addRequestHeaders =
     foldr (.) id . map (uncurry HTTP.insertHeader) . trOpt []
   where
     trOpt :: [(HTTP.HeaderName, [String])]

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -24,7 +24,6 @@ library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
   build-depends:       base               >= 4.5 && < 4.15,
                        bytestring         >= 0.9,
-                       data-default-class >= 0.0,
                        http-client        >= 0.4 && < 0.7,
                        http-types         >= 0.8,
                        hackage-security   >= 0.5 && < 0.7

--- a/hackage-security-http-client/src/Hackage/Security/Client/Repository/HttpLib/HttpClient.hs
+++ b/hackage-security-http-client/src/Hackage/Security/Client/Repository/HttpLib/HttpClient.hs
@@ -61,8 +61,7 @@ get manager reqHeaders uri callback = wrapCustomEx $ do
     -- TODO: setUri fails under certain circumstances; in particular, when
     -- the URI contains URL auth. Not sure if this is a concern.
     request' <- HttpClient.setUri HttpClient.defaultRequest uri
-    let request = setRequestHeaders reqHeaders
-                $ request'
+    let request = setRequestHeaders reqHeaders request'
     checkHttpException $ HttpClient.withResponse request manager $ \response -> do
       let br = wrapCustomEx $ HttpClient.responseBody response
       callback (getResponseHeaders response) br


### PR DESCRIPTION
See: https://github.com/commercialhaskell/stack/issues/5509

This doesn't fix that specific issue, since the actual code used is reimplemented in Pantry, but figured it would probably be good to patch upstream as well