### PR TITLE
Add support for Cabal-syntax

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -17,13 +17,17 @@ flag use-network-uri
   description: Are we using network-uri?
   manual: False
 
+flag Cabal-syntax
+  description: Are we using Cabal-syntax?
+  manual: False
+  default: False
+
 executable example-client
   main-is:             Main.hs
   other-modules: Prelude ExampleClient.Options
 
   build-depends:       base                 >= 4.5 && < 4.15,
                        bytestring           >= 0.9,
-                       Cabal                >= 1.12,
                        directory            >= 1.1,
                        filepath             >= 1.2,
                        optparse-applicative >= 0.11,
@@ -48,3 +52,9 @@ executable example-client
                    network     >= 2.6 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6
+
+  if flag(Cabal-syntax)
+    build-depends: Cabal-syntax >= 3.7 && < 3.9
+  else
+    build-depends: Cabal        >= 1.12 && < 3.7,
+                   Cabal-syntax <  3.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -39,6 +39,11 @@ flag use-old-time
   description: Are we using @old-time@?
   manual: False
 
+flag Cabal-syntax
+  description: Are we using Cabal-syntax?
+  manual: False
+  default: False
+
 executable hackage-repo-tool
   hs-source-dirs:      src
   main-is:             Main.hs
@@ -53,9 +58,6 @@ executable hackage-repo-tool
   -- the respective GHC release
   build-depends:       base                 >= 4.5  && < 4.15,
                        bytestring           >= 0.9  && < 0.12,
-                       Cabal                >= 1.14 && < 1.26
-                                         || >= 2.0  && < 2.6
-                                         || >= 3.0  && < 3.4,
                        directory            >= 1.1  && < 1.4,
                        filepath             >= 1.3  && < 1.5,
                        time                 >= 1.4  && < 1.10
@@ -83,6 +85,14 @@ executable hackage-repo-tool
                             || >= 3.0 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6
+
+  if flag(Cabal-syntax)
+    build-depends: Cabal-syntax >= 3.7 && < 3.9
+  else
+    build-depends: Cabal        >= 1.14    && < 1.26
+                             || >= 2.0     && < 2.6
+                             || >= 3.0     && < 3.7,
+                   Cabal-syntax <  3.7
 
 
   default-language:    Haskell2010

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -48,6 +48,11 @@ flag use-network-uri
   description: Are we using @network-uri@?
   manual: False
 
+flag Cabal-syntax
+  description: Are we using Cabal-syntax?
+  manual: False
+  default: False
+
 flag old-directory
   description: Use @directory@ < 1.2 and @old-time@
   manual:      False
@@ -114,9 +119,6 @@ library
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
                        bytestring        >= 0.9     && < 0.12,
-                       Cabal             >= 1.14    && < 1.26
-                                      || >= 2.0     && < 2.6
-                                      || >= 3.0     && < 3.8,
                        containers        >= 0.4     && < 0.7,
                        ed25519           >= 0.0     && < 0.1,
                        filepath          >= 1.2     && < 1.5,
@@ -148,6 +150,14 @@ library
     build-depends:     lukko      >= 0.1     && < 0.2
   else
     build-depends:     base       >= 4.10
+
+  if flag(Cabal-syntax)
+    build-depends: Cabal-syntax >= 3.7 && < 3.9
+  else
+    build-depends: Cabal        >= 1.14    && < 1.26
+                             || >= 2.0     && < 2.6
+                             || >= 3.0     && < 3.7,
+                   Cabal-syntax <  3.7
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -257,6 +267,9 @@ test-suite TestSuite
                        text,
                        time,
                        zlib
+
+  if flag(Cabal-syntax)
+    build-depends: Cabal-syntax
 
   -- dependencies exclusive to test-suite
   build-depends:       tasty            >= 1.2 && < 1.5,


### PR DESCRIPTION
Add support for new Cabal-syntax library: https://github.com/haskell/cabal/pull/7620

The only reference to Cabal I didn't know how to remove was the CPP here: https://github.com/haskell/hackage-security/blob/master/hackage-security/tests/TestSuite.hs#L18