### PR TITLE
Print filepath in fromAbsoluteFilePath error

### DIFF
--- a/hackage-security/src/Hackage/Security/Util/Path.hs
+++ b/hackage-security/src/Hackage/Security/Util/Path.hs
@@ -294,7 +294,7 @@ makeAbsolute (FsPath p) = mkPathNative <$> toAbsoluteFilePath p
 fromAbsoluteFilePath :: FilePath -> Path Absolute
 fromAbsoluteFilePath fp
   | FP.Native.isAbsolute fp = mkPathNative fp
-  | otherwise               = error "fromAbsoluteFilePath: not an absolute path"
+  | otherwise               = error ("fromAbsoluteFilePath: not an absolute path: " <> fp)
 
 {-------------------------------------------------------------------------------
   Wrappers around System.IO

--- a/hackage-security/src/Hackage/Security/Util/Path.hs
+++ b/hackage-security/src/Hackage/Security/Util/Path.hs
@@ -294,7 +294,7 @@ makeAbsolute (FsPath p) = mkPathNative <$> toAbsoluteFilePath p
 fromAbsoluteFilePath :: FilePath -> Path Absolute
 fromAbsoluteFilePath fp
   | FP.Native.isAbsolute fp = mkPathNative fp
-  | otherwise               = error ("fromAbsoluteFilePath: not an absolute path: " <> fp)
+  | otherwise               = error ("fromAbsoluteFilePath: not an absolute path: " ++ fp)
 
 {-------------------------------------------------------------------------------
   Wrappers around System.IO


### PR DESCRIPTION
I'm getting this error in `cabal` and have no idea what the directory is that is causing this problem.

https://github.com/input-output-hk/cardano-node/runs/4988750629?check_suite_focus=true

Printing the filepath that is causing the error will help making these kinds of issues easier to diagnose.