### PR TITLE
Fix #253: allow GHC-9.0 (base-4.15)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.6', '8.8.4', '8.6.5']
+        ghc: ['9.0.2', '8.10.7', '8.8.4', '8.6.5']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -26,7 +26,7 @@ executable example-client
   main-is:             Main.hs
   other-modules: Prelude ExampleClient.Options
 
-  build-depends:       base                 >= 4.5 && < 4.15,
+  build-depends:       base                 >= 4.5 && < 4.16,
                        bytestring           >= 0.9,
                        directory            >= 1.1,
                        filepath             >= 1.2,

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -56,7 +56,7 @@ executable hackage-repo-tool
 
   -- For boot libraries we try to accomodate the versions bundled with
   -- the respective GHC release
-  build-depends:       base                 >= 4.5  && < 4.15,
+  build-depends:       base                 >= 4.5  && < 4.16,
                        bytestring           >= 0.9  && < 0.12,
                        directory            >= 1.1  && < 1.4,
                        filepath             >= 1.3  && < 1.5,

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -31,7 +31,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
-  build-depends:       base             >= 4.5       && < 4.15,
+  build-depends:       base             >= 4.5       && < 4.16,
                        bytestring       >= 0.9       && < 0.12,
                        HTTP             >= 4000.2.19 && < 4000.4,
                        mtl              >= 2.1       && < 2.3,

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -23,7 +23,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
-  build-depends:       base        >= 4.5 && < 4.15,
+  build-depends:       base        >= 4.5 && < 4.16,
                        bytestring  >= 0.9,
                        process     >= 1.1,
                        hackage-security

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -22,7 +22,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
-  build-depends:       base               >= 4.5 && < 4.15,
+  build-depends:       base               >= 4.5 && < 4.16,
                        bytestring         >= 0.9,
                        http-client        >= 0.4 && < 0.7,
                        http-types         >= 0.8,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -115,7 +115,7 @@ library
                        Hackage.Security.Util.TypedEmbedded
                        MyPrelude
   -- We support ghc 7.4 (bundled with Cabal 1.14) and up
-  build-depends:       base              >= 4.5     && < 4.17,
+  build-depends:       base              >= 4.5     && < 4.16,
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
                        bytestring        >= 0.9     && < 0.12,


### PR DESCRIPTION
Fix #253: 
- allow GHC-9.0 (base-4.15)
- include 9.0.2 in CI

CI is green: https://github.com/andreasabel/hackage-security/runs/5156980985?check_suite_focus=true