### PR TITLE
Update version and changelog for hackage-security/v0.6.2.1

### DIFF
--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,5 +1,11 @@
 See also http://pvp.haskell.org/faq
 
+0.6.2.1
+-------
+
+* Allow GHC-9.0 (base-4.15) (#265)
+* Fix running `cabal repl hackage-security` (#263)
+
 0.6.2.0
 -------
 

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                hackage-security
-version:             0.6.2.0
+version:             0.6.2.1
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and


### PR DESCRIPTION
New release. PR to make sure nobody objects and nobody wants to squeeze in a feature before the release.