### PR TITLE
hackage-security.cabal: updated tested-with to GHC 9.0.2

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -29,8 +29,10 @@ category:            Distribution
 homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
-tested-with:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-                     GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:
+  GHC==9.0.2,
+  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
+  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 
 
 extra-source-files:


### PR DESCRIPTION
hackage-security.cabal: updated tested-with to GHC 9.0.2