### PR TITLE
fix typos

### DIFF
--- a/hackage-security-HTTP/src/Hackage/Security/Client/Repository/HttpLib/HTTP.hs
+++ b/hackage-security-HTTP/src/Hackage/Security/Client/Repository/HttpLib/HTTP.hs
@@ -40,7 +40,7 @@ import Hackage.Security.Util.Pretty
 --
 -- TODO: This currently uses the lazy bytestring API offered by the HTTP
 -- library. Unfortunately this provides no way of closing the connection when
--- the callback decides it doens't require any further input. It seems
+-- the callback decides it doesn't require any further input. It seems
 -- impossible however to implement a proper streaming API.
 -- See <https://github.com/haskell/HTTP/issues/86>.
 withClient :: (Browser -> HttpLib -> IO a) -> IO a

--- a/hackage-security/src/Hackage/Security/Client.hs
+++ b/hackage-security/src/Hackage/Security/Client.hs
@@ -89,7 +89,7 @@ data HasUpdates = HasUpdates | NoUpdates
 -- This implements the logic described in Section 5.1, "The client application",
 -- of the TUF spec. It checks which of the server metadata has changed, and
 -- downloads all changed metadata to the local cache. (Metadata here refers
--- both to the TUF security metadata as well as the Hackage packge index.)
+-- both to the TUF security metadata as well as the Hackage package index.)
 --
 -- You should pass @Nothing@ for the UTCTime _only_ under exceptional
 -- circumstances (such as when the main server is down for longer than the

--- a/hackage-security/src/Hackage/Security/Client/Formats.hs
+++ b/hackage-security/src/Hackage/Security/Client/Formats.hs
@@ -51,7 +51,7 @@ instance Unify Format where
 --
 -- Rather than having a general list here, we enumerate all possibilities.
 -- This means we are very precise about what we expect, and we avoid any runtime
--- errors about unexpect format definitions.
+-- errors about unexpected format definitions.
 --
 -- NOTE: If we add additional cases here (for dealing with additional formats)
 -- all calls to @error "inaccessible"@ need to be reevaluated.

--- a/hackage-security/src/Hackage/Security/TUF/Header.hs
+++ b/hackage-security/src/Hackage/Security/TUF/Header.hs
@@ -36,7 +36,7 @@ class HasHeader a where
 -- every file update.
 --
 -- 'Show' and 'Read' instance are defined in terms of the underlying 'Int'
--- (this is use for example by hackage during the backup process).
+-- (this is used for example by Hackage during the backup process).
 newtype FileVersion = FileVersion Int54
   deriving (Eq, Ord, Typeable)
 
@@ -55,7 +55,7 @@ instance Read FileVersion where
 newtype FileExpires = FileExpires (Maybe UTCTime)
   deriving (Eq, Ord, Show, Typeable)
 
--- | Occassionally it is useful to read only a header from a file.
+-- | Occasionally it is useful to read only a header from a file.
 --
 -- 'HeaderOnly' intentionally only has a 'FromJSON' instance (no 'ToJSON').
 data Header = Header {

--- a/hackage-security/src/Hackage/Security/TUF/Layout/Cache.hs
+++ b/hackage-security/src/Hackage/Security/TUF/Layout/Cache.hs
@@ -15,7 +15,7 @@ import Hackage.Security.Util.Path
 -- | Location of the various files we cache
 --
 -- Although the generic TUF algorithms do not care how we organize the cache,
--- we nonetheless specity this here because as long as there are tools which
+-- we nonetheless specify this here because as long as there are tools which
 -- access files in the cache directly we need to define the cache layout.
 -- See also comments for 'defaultCacheLayout'.
 data CacheLayout = CacheLayout {

--- a/hackage-security/src/Hackage/Security/TUF/Patterns.hs
+++ b/hackage-security/src/Hackage/Security/TUF/Patterns.hs
@@ -1,7 +1,7 @@
 -- | Patterns and replacements
 --
 -- NOTE: This module was developed to prepare for proper delegation (#39).
--- It is currently unusued.
+-- It is currently unused.
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE DeriveLift #-}


### PR DESCRIPTION
hackage-security-HTTP/src/Hackage/Security/Client/Repository/HttpLib/HTTP.hs
hackage-security/src/Hackage/Security/Client.hs
hackage-security/src/Hackage/Security/Client/Formats.hs
hackage-security/src/Hackage/Security/TUF/Header.hs
hackage-security/src/Hackage/Security/TUF/Layout/Cache.hs
hackage-security/src/Hackage/Security/TUF/Patterns.hs

<hr>

hackage-security/src/Hackage/Security/Key.hs

```
-- NOTE: The FromJSON and ToJSON instances for KeyId are ntentially omitted. Use
-- writeKeyAsId instead.
```

another typo as `ntentially` for someone else to correct in another PR