### PR TITLE
fix spelling errors

### DIFF
--- a/hackage-security/src/Hackage/Security/Client/Repository.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository.hs
@@ -181,7 +181,7 @@ data Repository down = DownloadedFile down => Repository {
     -- * Download the file from the repository and make it available at a
     --   temporary location
     -- * Use the provided file length to protect against endless data attacks.
-    --   (Repositories such as local repositories that are not suspectible to
+    --   (Repositories such as local repositories that are not susceptible to
     --   endless data attacks can safely ignore this argument.)
     -- * Move the file from its temporary location to its permanent location
     --   if verification succeeds.

--- a/hackage-security/src/Hackage/Security/Client/Repository/HttpLib.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/HttpLib.hs
@@ -45,7 +45,7 @@ data HttpLib = HttpLib {
     -- HTTP servers are normally expected to respond to a range request with
     -- a "206 Partial Content" response. However, servers can respond with a
     -- "200 OK" response, sending the entire file instead (for instance, this
-    -- may happen for servers that don't actually support range rqeuests, but
+    -- may happen for servers that don't actually support range requests, but
     -- for which we optimistically assumed they did). Implementations of
     -- 'HttpLib' may accept such a response and inform the @hackage-security@
     -- library that the whole file is being returned; the security library can

--- a/hackage-security/src/Hackage/Security/Key.hs
+++ b/hackage-security/src/Hackage/Security/Key.hs
@@ -145,8 +145,8 @@ createKey' = liftM Some . createKey
 -- | The key ID of a key, by definition, is the hexdigest of the SHA-256 hash of
 -- the canonical JSON form of the key where the private object key is excluded.
 --
--- NOTE: The FromJSON and ToJSON instances for KeyId are ntentially omitted. Use
--- writeKeyAsId instead.
+-- NOTE: The FromJSON and ToJSON instances for KeyId are intentionally omitted.
+-- Use writeKeyAsId instead.
 newtype KeyId = KeyId { keyIdString :: String }
   deriving (Show, Eq, Ord)
 


### PR DESCRIPTION
hackage-security/src/Hackage/Security/Client/Repository.hs
hackage-security/src/Hackage/Security/Client/Repository/HttpLib.hs
hackage-security/src/Hackage/Security/Key.hs

@Mikolaj

as per https://github.com/haskell/hackage-security/pull/269#issuecomment-1067411773
\+ a couple more errors