### PR TITLE
Bump Cabal-syntax bound for 3.9 dev version

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -155,7 +155,7 @@ library
     build-depends:     base       >= 4.10
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.9
+    build-depends: Cabal-syntax >= 3.7 && < 3.10
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6


### PR DESCRIPTION
Will also revise on Hackage.