### PR TITLE
Support mtl-2.3

### DIFF
--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -38,7 +38,7 @@ library
   build-depends:       base             >= 4.5       && < 4.18,
                        bytestring       >= 0.9       && < 0.12,
                        HTTP             >= 4000.2.19 && < 4000.5,
-                       mtl              >= 2.1       && < 2.3,
+                       mtl              >= 2.1       && < 2.4,
                        zlib             >= 0.5       && < 0.7,
                        hackage-security >= 0.5       && < 0.7
   hs-source-dirs:      src

--- a/hackage-security/src/Hackage/Security/Client/Repository/Remote.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/Remote.hs
@@ -30,7 +30,8 @@ module Hackage.Security.Client.Repository.Remote (
 import MyPrelude
 import Control.Concurrent
 import Control.Exception
-import Control.Monad.Cont
+import Control.Monad (when, unless)
+import Control.Monad.IO.Class (MonadIO)
 import Data.List (nub, intercalate)
 import Data.Typeable
 import Network.URI hiding (uriPath, path)
@@ -337,7 +338,7 @@ pickDownloadMethod RemoteConfig{..} attemptNr remoteFile =
         unless rangeSupport $ exit $ CannotUpdate hasGz UpdateImpossibleUnsupported
 
         -- We must already have a local file to be updated
-        mCachedIndex <- lift $ Cache.getCachedIndex cfgCache (hasFormatGet hasGz)
+        mCachedIndex <- liftIO $ Cache.getCachedIndex cfgCache (hasFormatGet hasGz)
         cachedIndex  <- case mCachedIndex of
           Nothing -> exit $ CannotUpdate hasGz UpdateImpossibleNoLocalCopy
           Just fp -> return fp

--- a/hackage-security/src/Hackage/Security/Client/Verify.hs
+++ b/hackage-security/src/Hackage/Security/Client/Verify.hs
@@ -12,7 +12,9 @@ module Hackage.Security.Client.Verify (
 
 import MyPrelude
 import Control.Exception
-import Control.Monad.Reader
+import Control.Monad (join, void)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Reader (ReaderT, runReaderT, ask)
 import Data.IORef
 
 import Hackage.Security.Util.IO

--- a/hackage-security/src/Hackage/Security/JSON.hs
+++ b/hackage-security/src/Hackage/Security/JSON.hs
@@ -41,8 +41,9 @@ module Hackage.Security.JSON (
 import MyPrelude
 import Control.Arrow (first, second)
 import Control.Exception
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad (unless, liftM)
+import Control.Monad.Except (MonadError, Except, ExceptT, runExcept, runExceptT, throwError)
+import Control.Monad.Reader (MonadReader, Reader, runReader, local, ask)
 import Data.Functor.Identity
 import Data.Typeable (Typeable)
 import qualified Data.ByteString.Lazy as BS.L

--- a/hackage-security/src/Hackage/Security/TUF/Patterns.hs
+++ b/hackage-security/src/Hackage/Security/TUF/Patterns.hs
@@ -27,7 +27,7 @@ module Hackage.Security.TUF.Patterns (
   ) where
 
 import MyPrelude
-import Control.Monad.Except
+import Control.Monad (guard)
 import Language.Haskell.TH (Q, Exp)
 import System.FilePath.Posix
 import qualified Language.Haskell.TH.Syntax as TH

--- a/hackage-security/src/Hackage/Security/Trusted/TCB.hs
+++ b/hackage-security/src/Hackage/Security/Trusted/TCB.hs
@@ -28,7 +28,8 @@ module Hackage.Security.Trusted.TCB (
 
 import MyPrelude
 import Control.Exception
-import Control.Monad.Except
+import Control.Monad (when, unless)
+import Control.Monad.Except (Except, runExcept, throwError)
 import Data.Typeable
 import Data.Time
 import Hackage.Security.TUF

--- a/hackage-security/src/Hackage/Security/Util/Exit.hs
+++ b/hackage-security/src/Hackage/Security/Util/Exit.hs
@@ -1,7 +1,8 @@
 module Hackage.Security.Util.Exit where
 
 import MyPrelude
-import Control.Monad.Except
+import Control.Monad (liftM)
+import Control.Monad.Except (ExceptT, runExceptT, throwError)
 
 {-------------------------------------------------------------------------------
   Auxiliary: multiple exit points


### PR DESCRIPTION
Resolves #288. 

Tested with 
```
cabal build all -c 'transformers >= 0.6' -c 'mtl >= 2.3' --allow-newer='Cabal-syntax:mtl,Cabal-syntax:transformers,Cabal:mtl,Cabal:transformers'
```