### PR TITLE
Bump Cabal-syntax bound to let it work with cabal 3.10 and 3.11dev

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -57,7 +57,7 @@ executable example-client
     build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.9
+    build-depends: Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.12 && < 3.7,
                    Cabal-syntax <  3.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -90,7 +90,7 @@ executable hackage-repo-tool
     build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.10
+    build-depends: Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -154,7 +154,7 @@ library
     build-depends:     base       >= 4.10
 
   if flag(Cabal-syntax) && impl(ghc >= 8.2)
-    build-depends: Cabal-syntax >= 3.7 && < 3.10
+    build-depends: Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6
@@ -271,8 +271,8 @@ test-suite TestSuite
                        zlib
 
   if flag(Cabal-syntax) && impl(ghc >= 8.2)
-    build-depends: Cabal        >= 3.7 && < 3.10,
-                   Cabal-syntax >= 3.7 && < 3.10
+    build-depends: Cabal        >= 3.7 && < 3.12,
+                   Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6


### PR DESCRIPTION
I plan to just revise this on Hackage for both packages.