### PR TITLE
Bumps for GHC 9.6

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220812
+# version: 0.15.20230211
 #
-# REGENDATA ("0.15.20220812",["github","cabal.project"])
+# REGENDATA ("0.15.20230211",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,14 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.6.0.20230128
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.6.0.20230128
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.4.4
+            compilerKind: ghc
+            compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.6
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -105,7 +110,7 @@ jobs:
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
@@ -113,7 +118,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -131,20 +137,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER > 90401)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -208,7 +214,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -282,8 +288,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -319,7 +325,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
@@ -331,3 +337,9 @@ jobs:
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' --dependencies-only -j2 all ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all ; fi
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -334,8 +334,8 @@ jobs:
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
-          rm -f cabal.project.local
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+          if [ $((HCNUMVER < 90600)) -ne 0 ] ; then rm -f cabal.project.local ; fi
+          if [ $((HCNUMVER < 90600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all ; fi
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,14 +8,20 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230211
+# version: 0.15.20230217
 #
-# REGENDATA ("0.15.20230211",["github","cabal.project"])
+# REGENDATA ("0.15.20230217",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - ci-*
+  pull_request:
+    branches:
+      - master
+      - ci-*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -28,9 +34,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230128
+          - compiler: ghc-9.6.0.20230210
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230128
+            compilerVersion: 9.6.0.20230210
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.4.4

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,32 +9,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.4.1', '9.2.4', '9.0.2', '8.10.7']
+        ghc: ['9.4.4', '9.2.5', '9.0.2', '8.10.7']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: actions/checkout@v3
+
+    - uses: haskell/actions/setup@v2
+      id:   setup
       with:
-        ghc-version: ${{ matrix.ghc }}
+        ghc-version:   ${{ matrix.ghc }}
         cabal-version: '3.8.1.0'
+        cabal-update:  true
 
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       env:
-        cache-name: cache-cabal
+        cache-name: haskell.yml
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key:          ${{ runner.os }}-${{ env.cache-name }}-ghc-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
+        restore-keys: ${{ runner.os }}-${{ env.cache-name }}-ghc-${{ matrix.ghc }}-
 
     - name: Install dependencies
       run: |
-        cabal update
         cabal build --only-dependencies --enable-tests --enable-benchmarks -vnormal+nowrap all
+
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks -j1 -vnormal+nowrap all
+
     - name: Run tests
       run: cabal test -j1 -vnormal+nowrap all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,14 @@
 name: MacOS, Ubuntu, Windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - ci-*
+  pull_request:
+    branches:
+      - master
+      - ci-*
 
 jobs:
   build:

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,6 +2,10 @@ branches: master ci-*
 
 ghc-head: True
 
+-- Andreas, 2023-02-20: see https://github.com/haskell/hackage-security/pull/291
+-- unconstrained build with head.hackage produces failing build plans
+unconstrained: < 9.6
+
 constraint-set no-lukko
   ghc: >=8.2
   constraints: hackage-security -lukko

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,5 @@
+branches: master ci-*
+
 ghc-head: True
 
 constraint-set no-lukko

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -68,7 +68,7 @@ executable example-client
     build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.9
+    build-depends: Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.12 && < 3.7,
                    Cabal-syntax <  3.7

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -12,9 +12,20 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 flag use-network-uri
   description: Are we using network-uri?

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -40,7 +40,7 @@ executable example-client
   main-is:             Main.hs
   other-modules: Prelude ExampleClient.Options
 
-  build-depends:       base                 >= 4.5 && < 4.18,
+  build-depends:       base                 >= 4.5 && < 4.19,
                        bytestring           >= 0.9,
                        directory            >= 1.1,
                        filepath             >= 1.2,

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -101,7 +101,7 @@ executable hackage-repo-tool
     build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.10
+    build-depends: Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -23,9 +23,20 @@ homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 extra-source-files:
   ChangeLog.md README.md

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -70,13 +70,13 @@ executable hackage-repo-tool
 
   -- For boot libraries we try to accomodate the versions bundled with
   -- the respective GHC release
-  build-depends:       base                 >= 4.5  && < 4.18,
+  build-depends:       base                 >= 4.5  && < 4.19,
                        bytestring           >= 0.9  && < 0.12,
                        directory            >= 1.1  && < 1.4,
                        filepath             >= 1.3  && < 1.5,
                        time                 >= 1.4  && < 1.13
   if !os(windows)
-    build-depends:     unix                 >= 2.5  && < 2.8
+    build-depends:     unix                 >= 2.5  && < 2.9
 
   if flag(use-old-time)
     build-depends: directory < 1.2

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
 version:             0.1.1.3
+x-revision:          2
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -16,9 +16,20 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 extra-source-files:
   ChangeLog.md

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -18,9 +18,20 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 extra-source-files:
   ChangeLog.md

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -46,7 +46,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
-  build-depends:       base             >= 4.5       && < 4.18,
+  build-depends:       base             >= 4.5       && < 4.19,
                        bytestring       >= 0.9       && < 0.12,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.1       && < 2.4,

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security-HTTP
 version:             0.1.1.1
-x-revision:          2
+x-revision:          5
 synopsis:            Hackage security bindings against the HTTP library
 description:         The hackage security library provides a 'HttpLib'
                      abstraction to allow to bind against different HTTP

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -37,7 +37,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
-  build-depends:       base        >= 4.5 && < 4.18,
+  build-depends:       base        >= 4.5 && < 4.19,
                        bytestring  >= 0.9,
                        process     >= 1.1,
                        hackage-security

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -16,9 +16,20 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 flag use-network-uri
   description: Are we using network-uri?

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -36,7 +36,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
-  build-depends:       base               >= 4.5 && < 4.18,
+  build-depends:       base               >= 4.5 && < 4.19,
                        bytestring         >= 0.9,
                        http-client        >= 0.4 && < 0.8,
                        http-types         >= 0.8,

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -15,9 +15,20 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 flag use-network-uri
   description: Are we using network-uri?

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -31,9 +31,20 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
-  GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.6
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
+  GHC == 7.8.4
+  GHC == 7.6.3
+  GHC == 7.4.2
 
 extra-source-files:
   ChangeLog.md

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -128,7 +128,7 @@ library
                        Hackage.Security.Util.TypedEmbedded
                        MyPrelude
   -- We support ghc 7.4 (bundled with Cabal 1.14) and up
-  build-depends:       base              >= 4.5     && < 4.18,
+  build-depends:       base              >= 4.5     && < 4.19,
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
                        bytestring        >= 0.9     && < 0.12,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.3
-x-revision:          1
+x-revision:          2
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -283,8 +283,8 @@ test-suite TestSuite
                        zlib
 
   if flag(Cabal-syntax) && impl(ghc >= 8.2)
-    build-depends: Cabal        >= 3.7 && < 3.10,
-                   Cabal-syntax >= 3.7 && < 3.10
+    build-depends: Cabal        >= 3.7 && < 3.12,
+                   Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.3
+x-revision:          1
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -165,7 +165,7 @@ library
     build-depends:     base       >= 4.10
 
   if flag(Cabal-syntax) && impl(ghc >= 8.2)
-    build-depends: Cabal-syntax >= 3.7 && < 3.10
+    build-depends: Cabal-syntax >= 3.7 && < 3.12
   else
     build-depends: Cabal        >= 1.14    && < 1.26
                              || >= 2.0     && < 2.6


### PR DESCRIPTION
- Bump `tested-with` and Haskell CI to GHC 9.6.1 alpha, 9.4.4 and 9.2.6
- bump `base`, `unix`, `Cabal-syntax`

TODO:
- [x] Also bump the other CI


CI uses Cabal-syntax 3.9.0.0: https://github.com/haskell/hackage-security/actions/runs/4214000092/jobs/7314153972#step:15:1024