### PR TITLE
Allow bytestring-0.12 and test it in Haskell CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -284,6 +284,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           constraints: base-compat >= 0.12.2
+          allow-newer: bytestring
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
@@ -340,6 +341,11 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set bytestring-0.12
+        run: |
+          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
+          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
       - name: constraint set no-lukko
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' --dependencies-only -j2 all ; fi

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -15,7 +15,30 @@ haddock: >= 8.6
 raw-project
   constraints:
     base-compat >= 0.12.2
+  --
+  -- The following is meant to be for constraint-set bytestring-0.12 only,
+  -- but there is currently no way to enable `allow-newer: bytestring`
+  -- just for the constraint set.
+  --
+  -- Since core library `bytestring` is constrained to `installed`,
+  -- it is not harmful to allow newer `bytestring` in the default runs
+  -- as well---it will have no effect there.
+  --
+  allow-newer: bytestring
 
 constraint-set no-lukko
   ghc: >=8.2
   constraints: hackage-security -lukko
+
+constraint-set bytestring-0.12
+  -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
+  ghc: >= 8.0
+  constraints: bytestring >= 0.12
+  --
+  -- The following is silently ignored here:
+  --
+  -- raw-project
+  --   allow-newer: bytestring
+  --
+  tests: True
+  run-tests: True

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
 version:             0.1.1.3
-x-revision:          2
+x-revision:          3
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories
@@ -72,7 +72,7 @@ executable hackage-repo-tool
   -- For boot libraries we try to accomodate the versions bundled with
   -- the respective GHC release
   build-depends:       base                 >= 4.5  && < 4.19,
-                       bytestring           >= 0.9  && < 0.12,
+                       bytestring           >= 0.9  && < 0.13,
                        directory            >= 1.1  && < 1.4,
                        filepath             >= 1.3  && < 1.5,
                        time                 >= 1.4  && < 1.13

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security-HTTP
 version:             0.1.1.1
-x-revision:          5
+x-revision:          6
 synopsis:            Hackage security bindings against the HTTP library
 description:         The hackage security library provides a 'HttpLib'
                      abstraction to allow to bind against different HTTP
@@ -47,7 +47,7 @@ flag use-network-uri
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
   build-depends:       base             >= 4.5       && < 4.19,
-                       bytestring       >= 0.9       && < 0.12,
+                       bytestring       >= 0.9       && < 0.13,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.1       && < 2.4,
                        zlib             >= 0.5       && < 0.7,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.3
-x-revision:          4
+x-revision:          5
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -132,7 +132,7 @@ library
   build-depends:       base              >= 4.5     && < 4.19,
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
-                       bytestring        >= 0.9     && < 0.12,
+                       bytestring        >= 0.9     && < 0.13,
                        containers        >= 0.4     && < 0.7,
                        ed25519           >= 0.0     && < 0.1,
                        filepath          >= 1.2     && < 1.5,


### PR DESCRIPTION
Published `bytestring <0.13` revisions for:
- hackage-security
- hackage-security-HTTP
- hackage-repo-tool