### PR TITLE
Bumps: allow base-4.19 (GHC 9.8), containers-0.7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20230911
+# version: 0.17.20231002
 #
-# REGENDATA ("0.17.20230911",["github","cabal.project"])
+# REGENDATA ("0.17.20231002",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.8.0.20230929
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.8.0.20230929
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.6.3
+            compilerKind: ghc
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.7
@@ -141,7 +146,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER > 90602)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -269,7 +274,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           constraints: base-compat >= 0.12.2
-          allow-newer: bytestring
+          allow-newer: containers
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
@@ -326,13 +331,13 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
-      - name: constraint set bytestring-0.12
+      - name: constraint set containers-0.7
         run: |
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers >= 0.7' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers >= 0.7' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers >= 0.7' all ; fi
+          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers >= 0.7' all ; fi
       - name: constraint set no-lukko
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all --dry-run ; fi

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,5 @@
 branches: master
 
-ghc-head: True
-
 -- Andreas, 2023-07-01: We use some haddock features that are new in 8.6.
 haddock: >= 8.6
 
@@ -15,30 +13,15 @@ haddock: >= 8.6
 raw-project
   constraints:
     base-compat >= 0.12.2
-  --
-  -- The following is meant to be for constraint-set bytestring-0.12 only,
-  -- but there is currently no way to enable `allow-newer: bytestring`
-  -- just for the constraint set.
-  --
-  -- Since core library `bytestring` is constrained to `installed`,
-  -- it is not harmful to allow newer `bytestring` in the default runs
-  -- as well---it will have no effect there.
-  --
-  allow-newer: bytestring
 
 constraint-set no-lukko
   ghc: >=8.2
   constraints: hackage-security -lukko
 
-constraint-set bytestring-0.12
-  -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
-  ghc: >= 8.0
-  constraints: bytestring >= 0.12
-  --
-  -- The following is silently ignored here:
-  --
-  -- raw-project
-  --   allow-newer: bytestring
-  --
+constraint-set containers-0.7
+  ghc: >= 8.2 && < 9.8
+  constraints: containers >= 0.7
   tests: True
   run-tests: True
+raw-project
+  allow-newer: containers

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -12,7 +12,8 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -37,7 +38,7 @@ executable example-client
   main-is:             Main.hs
   other-modules: Prelude ExampleClient.Options
 
-  build-depends:       base                 >= 4.5 && < 4.19,
+  build-depends:       base                 >= 4.5 && < 4.20,
                        bytestring           >= 0.9,
                        directory            >= 1.1,
                        filepath             >= 1.2,

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
 version:             0.1.1.3
-x-revision:          3
+x-revision:          4
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories
@@ -24,7 +24,8 @@ homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -68,7 +69,7 @@ executable hackage-repo-tool
 
   -- For boot libraries we try to accomodate the versions bundled with
   -- the respective GHC release
-  build-depends:       base                 >= 4.5  && < 4.19,
+  build-depends:       base                 >= 4.5  && < 4.20,
                        bytestring           >= 0.9  && < 0.13,
                        directory            >= 1.1  && < 1.4,
                        filepath             >= 1.3  && < 1.5,

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -16,7 +16,8 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security-HTTP
 version:             0.1.1.1
-x-revision:          6
+x-revision:          7
 synopsis:            Hackage security bindings against the HTTP library
 description:         The hackage security library provides a 'HttpLib'
                      abstraction to allow to bind against different HTTP
@@ -18,7 +18,8 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -43,7 +44,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
-  build-depends:       base             >= 4.5       && < 4.19,
+  build-depends:       base             >= 4.5       && < 4.20,
                        bytestring       >= 0.9       && < 0.13,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.1       && < 2.4,

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -16,7 +16,8 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -34,7 +35,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
-  build-depends:       base        >= 4.5 && < 4.19,
+  build-depends:       base        >= 4.5 && < 4.20,
                        bytestring  >= 0.9,
                        process     >= 1.1,
                        hackage-security

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -15,7 +15,8 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -33,7 +34,7 @@ flag use-network-uri
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
-  build-depends:       base               >= 4.5 && < 4.19,
+  build-depends:       base               >= 4.5 && < 4.20,
                        bytestring         >= 0.9,
                        http-client        >= 0.4 && < 0.8,
                        http-types         >= 0.8,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.3
-x-revision:          6
+x-revision:          7
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -32,7 +32,8 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.0
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -126,11 +127,11 @@ library
                        Hackage.Security.Util.TypedEmbedded
                        MyPrelude
   -- We support ghc 7.4 (bundled with Cabal 1.14) and up
-  build-depends:       base              >= 4.5     && < 4.19,
+  build-depends:       base              >= 4.5     && < 4.20,
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
                        bytestring        >= 0.9     && < 0.13,
-                       containers        >= 0.4     && < 0.7,
+                       containers        >= 0.4     && < 0.8,
                        ed25519           >= 0.0     && < 0.1,
                        filepath          >= 1.2     && < 1.5,
                        parsec            >= 3.1     && < 3.2,

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -15,9 +15,9 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC==9.4.1, GHC==9.2.4, GHC==9.0.2,
+  GHC==9.6.3,  GHC==9.4.5, GHC==9.2.8, GHC==9.0.2,
   GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
-  GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+  GHC==7.10.3
 
 executable precompute-fileinfo
   main-is:             Main.hs


### PR DESCRIPTION
Published revisions:

2023-10-04T17:12:14Z  	AndreasAbel	  [hackage-repo-tool-0.1.1.3-r4](https://hackage.haskell.org/package/hackage-repo-tool-0.1.1.3/revisions)
2023-10-04T17:11:54Z  	AndreasAbel	  [hackage-security-0.6.2.3-r7](https://hackage.haskell.org/package/hackage-security-0.6.2.3/revisions)
2023-10-04T17:11:32Z  	AndreasAbel	  [hackage-security-HTTP-0.1.1.1-r7](https://hackage.haskell.org/package/hackage-security-HTTP-0.1.1.1/revisions)

NB: I removed the `bytestring-0.12` constraint-set from CI because it is covered by the GHC 9.8 build.