### PR TITLE
Bump template-haskell bound, update CI to GHC 9.8.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231002
+# version: 0.17.20231012
 #
-# REGENDATA ("0.17.20231002",["github","cabal.project"])
+# REGENDATA ("0.17.20231012",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,11 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230929
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230929
+            compilerVersion: 9.8.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.6.3
             compilerKind: ghc
             compilerVersion: 9.6.3
@@ -65,27 +65,27 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-7.10.3
             compilerKind: ghc
@@ -97,7 +97,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
@@ -146,7 +146,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -175,18 +175,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -276,9 +264,6 @@ jobs:
           constraints: base-compat >= 0.12.2
           allow-newer: containers
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(example-client|hackage-repo-tool|hackage-root-tool|hackage-security|hackage-security-HTTP|hackage-security-curl|hackage-security-http-client)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-      - ci-*
   pull_request:
     branches:
       - master
-      - ci-*
 
 jobs:
   build:
@@ -17,12 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.6.2', '9.4.5', '9.2.8']
+        ghc: ['9.8.1', '9.6.3', '9.4.7']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id:   setup
       with:
         ghc-version:   ${{ matrix.ghc }}

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -24,7 +24,7 @@ homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -18,7 +18,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -15,7 +15,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.3
-x-revision:          7
+x-revision:          8
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -32,7 +32,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
@@ -140,7 +140,7 @@ library
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
                        -- functionality, 0.5.0 changes type of serialise
                        tar               >= 0.5     && < 0.6,
-                       template-haskell  >= 2.7     && < 2.21,
+                       template-haskell  >= 2.7     && < 2.22,
                        time              >= 1.2     && < 1.13,
                        transformers      >= 0.3     && < 0.7,
                        zlib              >= 0.5     && < 0.7,


### PR DESCRIPTION
Closes #300.

Published as revision 8 of `hackage-security-0.6.2.3`: https://hackage.haskell.org/package/hackage-security-0.6.2.3/revisions/
