### PR TITLE
Allow tar-0.6, bump CI to GHC 9.4.8, delete old cabal flags

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231012
+# version: 0.17.20231112
 #
-# REGENDATA ("0.17.20231012",["github","cabal.project"])
+# REGENDATA ("0.17.20231112",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -100,20 +100,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -133,13 +131,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
             echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
 version:             0.1.1.3
-x-revision:          4
+x-revision:          5
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories
@@ -26,7 +26,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -87,7 +87,7 @@ executable hackage-repo-tool
   -- to reduce the risk of semantic differences
   build-depends:       microlens            >= 0.4.11.2 && < 0.5,
                        optparse-applicative >= 0.15.1   && < 0.18,
-                       tar                  >= 0.5      && < 0.6,
+                       tar                  >= 0.5      && < 0.7,
                        zlib                 >= 0.6      && < 0.7,
                        hackage-security     >= 0.6      && < 0.7
 

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -20,7 +20,7 @@ build-type:          Simple
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,5 +1,12 @@
 See also http://pvp.haskell.org/faq
 
+0.6.2.4
+-------
+
+* Allow `tar-0.6`
+* Drop support for GHC < 7.8 in favor of `PatternSynonyms`
+* Tested with GHC 7.10 - 9.8
+
 0.6.2.3
 -------
 

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -5,6 +5,7 @@ See also http://pvp.haskell.org/faq
 
 * Allow `tar-0.6`
 * Drop support for GHC < 7.8 in favor of `PatternSynonyms`
+* Drop flags `base48`, `mtl21`, `old-directory` and support for GHC 7.8, `mtl < 2.2` and `directory < 1.2`
 * Tested with GHC 7.10 - 9.8
 
 0.6.2.3

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,6 @@
 cabal-version:       1.12
 name:                hackage-security
-version:             0.6.2.3
-x-revision:          9
+version:             0.6.2.4
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -127,7 +126,8 @@ library
                        Hackage.Security.Util.TypedEmbedded
                        MyPrelude
   -- We support ghc 7.4 (bundled with Cabal 1.14) and up
-  build-depends:       base              >= 4.5     && < 4.20,
+  build-depends:       base              >= 4.7     && < 4.20,
+                         -- PatternSynonyms are only available since GHC 7.8 (base 4.7)
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
                        bytestring        >= 0.9     && < 0.13,
@@ -185,6 +185,7 @@ library
                        NamedFieldPuns
                        NoImplicitPrelude
                        NoMonomorphismRestriction
+                       PatternSynonyms
                        RankNTypes
                        RecordWildCards
                        ScopedTypeVariables

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.3
-x-revision:          8
+x-revision:          9
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -34,7 +34,7 @@ build-type:          Simple
 tested-with:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -139,7 +139,7 @@ library
                        cryptohash-sha256 >= 0.11    && < 0.12,
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
                        -- functionality, 0.5.0 changes type of serialise
-                       tar               >= 0.5     && < 0.6,
+                       tar               >= 0.5     && < 0.7,
                        template-haskell  >= 2.7     && < 2.22,
                        time              >= 1.2     && < 1.13,
                        transformers      >= 0.3     && < 0.7,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -51,10 +51,6 @@ source-repository head
   type: git
   location: https://github.com/haskell/hackage-security.git
 
-flag base48
-  description: Are we using @base@ 4.8 or later?
-  manual: False
-
 flag use-network-uri
   description: Are we using @network-uri@?
   manual: False
@@ -63,16 +59,6 @@ flag Cabal-syntax
   description: Are we using Cabal-syntax?
   manual: False
   default: False
-
-flag old-directory
-  description: Use @directory@ < 1.2 and @old-time@
-  manual:      False
-  default:     False
-
-flag mtl21
-  description: Use @mtl@ < 2.2 and @mtl-compat@
-  manual:      False
-  default:     False
 
 flag lukko
   description: Use @lukko@ for file-locking, otherwise use @GHC.IO.Handle.Lock@
@@ -126,17 +112,19 @@ library
                        Hackage.Security.Util.TypedEmbedded
                        MyPrelude
   -- We support ghc 7.4 (bundled with Cabal 1.14) and up
-  build-depends:       base              >= 4.7     && < 4.20,
+  build-depends:       base              >= 4.8     && < 4.20,
                          -- PatternSynonyms are only available since GHC 7.8 (base 4.7)
                        base16-bytestring >= 0.1.1   && < 1.1,
                        base64-bytestring >= 1.0     && < 1.3,
                        bytestring        >= 0.9     && < 0.13,
                        containers        >= 0.4     && < 0.8,
+                       cryptohash-sha256 >= 0.11    && < 0.12,
+                       directory         >= 1.2     && < 1.4,
                        ed25519           >= 0.0     && < 0.1,
                        filepath          >= 1.2     && < 1.5,
+                       mtl               >= 2.2     && < 2.4,
                        parsec            >= 3.1     && < 3.2,
                        pretty            >= 1.0     && < 1.2,
-                       cryptohash-sha256 >= 0.11    && < 0.12,
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
                        -- functionality, 0.5.0 changes type of serialise
                        tar               >= 0.5     && < 0.7,
@@ -146,17 +134,6 @@ library
                        zlib              >= 0.5     && < 0.7,
                        -- whatever versions are bundled with ghc:
                        ghc-prim
-  if flag(old-directory)
-    build-depends:     directory  >= 1.1.0.2 && < 1.2,
-                       old-time   >= 1 &&       < 1.2
-  else
-    build-depends:     directory  >= 1.2 && < 1.4
-
-  if flag(mtl21)
-    build-depends:     mtl        >= 2.1     && < 2.2,
-                       mtl-compat >= 0.2     && < 0.3
-  else
-    build-depends:     mtl        >= 2.2     && < 2.4
 
   if flag(lukko)
     build-depends:     lukko      >= 0.1     && < 0.2
@@ -194,10 +171,14 @@ library
                        TypeFamilies
                        TypeOperators
                        ViewPatterns
-  other-extensions:    BangPatterns
+  other-extensions:
+                       AllowAmbiguousTypes
+                       BangPatterns
                        CPP
                        OverlappingInstances
                        PackageImports
+                       RoleAnnotations
+                       StaticPointers
                        UndecidableInstances
 
   -- use the new stage1/cross-compile-friendly DeriveLift extension for GHC 8.0+
@@ -207,11 +188,6 @@ library
     other-extensions: TemplateHaskell
 
   ghc-options:         -Wall
-
-  if flag(base48)
-    build-depends: base >= 4.8
-  else
-    build-depends: base < 4.8, old-locale == 1.0.*
 
   -- The URI type got split out off the network package after version 2.5, and
   -- moved to a separate network-uri package. Since we don't need the rest of
@@ -251,13 +227,6 @@ library
                             || >= 3.0 && < 3.2
   else
     build-depends: network     >= 2.5 && < 2.6
-
-  if impl(ghc >= 7.8)
-     other-extensions: RoleAnnotations
-
-  if impl(ghc >= 7.10)
-     other-extensions: AllowAmbiguousTypes
-                       StaticPointers
 
 test-suite TestSuite
   type:                exitcode-stdio-1.0

--- a/hackage-security/src/Hackage/Security/Client/Repository/Cache.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/Cache.hs
@@ -20,7 +20,7 @@ import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Maybe
-import Codec.Archive.Tar (Entries(..))
+import Codec.Archive.Tar (Entries, pattern Done, pattern Fail, pattern Next)
 import Codec.Archive.Tar.Index (TarIndex, IndexBuilder, TarEntryOffset)
 import qualified Codec.Archive.Tar       as Tar
 import qualified Codec.Archive.Tar.Index as TarIndex


### PR DESCRIPTION
* Allow `tar-0.6`
* Drop support for GHC < 7.8 in favor of `PatternSynonyms`
* Drop flags `base48`, `mtl21`, `old-directory` and support for GHC 7.8, `mtl < 2.2` and `directory < 1.2`