### PR TITLE
The latest link for nix builds has moved

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
--- See http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+-- SEE: https://cabal.readthedocs.io/en/latest/how-to-build-like-nix.html
 
 packages: hackage-security
           hackage-security-http-client


### PR DESCRIPTION
Not sure if we still want or need this link but in the latest manual it has moved hasn't it?