### PR TITLE
zlib 0.7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20240106
+# version: 0.17.20240127
 #
-# REGENDATA ("0.17.20240106",["github","cabal.project"])
+# REGENDATA ("0.17.20240127",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -246,7 +246,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -304,7 +304,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' --dependencies-only -j2 all ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all ; fi
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.8.1', '9.6.3', '9.4.7']
+        ghc: ['9.8.1', '9.6.4', '9.4.8']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: haskell-actions/setup@v2
       id:   setup
@@ -28,7 +28,7 @@ jobs:
         cabal-update:  true
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: haskell.yml
       with:

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -13,7 +13,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,7 +1,6 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
 version:             0.1.1.3
-x-revision:          5
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories
@@ -76,7 +75,7 @@ executable hackage-repo-tool
   build-depends:       microlens            >= 0.4.11.2 && < 0.5,
                        optparse-applicative >= 0.15.1   && < 0.18,
                        tar                  >= 0.5      && < 0.7,
-                       zlib                 >= 0.6      && < 0.7,
+                       zlib                 >= 0.6      && < 0.8,
                        hackage-security     >= 0.6      && < 0.7
 
   -- see comments in hackage-security.cabal

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -25,7 +25,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -19,7 +19,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security-HTTP
 version:             0.1.1.1
-x-revision:          7
+
 synopsis:            Hackage security bindings against the HTTP library
 description:         The hackage security library provides a 'HttpLib'
                      abstraction to allow to bind against different HTTP
@@ -47,7 +47,7 @@ library
                        bytestring       >= 0.9       && < 0.13,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.1       && < 2.4,
-                       zlib             >= 0.5       && < 0.7,
+                       zlib             >= 0.5       && < 0.8,
                        hackage-security >= 0.5       && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -128,7 +128,7 @@ library
                        template-haskell  >= 2.7     && < 2.22,
                        time              >= 1.5     && < 1.13,
                        transformers      >= 0.3     && < 0.7,
-                       zlib              >= 0.5     && < 0.7,
+                       zlib              >= 0.5     && < 0.8,
                        -- whatever versions are bundled with ghc:
                        ghc-prim
 

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -32,7 +32,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.8.1
-  GHC == 9.6.3
+  GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -15,7 +15,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC==9.6.3,  GHC==9.4.5, GHC==9.2.8, GHC==9.0.2,
+  GHC==9.8.1,  GHC==9.6.4, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2,
   GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
 
 executable precompute-fileinfo


### PR DESCRIPTION
- Bump CI 'haskell.yml' to latest GHC minors and latest actions
- Haskell-CI: bump to GHC 9.6.4
- Allow zlib-0.7
