### PR TITLE
Bump Cabal and Cabal-syntax to allow 3.12

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -63,7 +63,7 @@ executable example-client
     build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.12
+    build-depends: Cabal-syntax >= 3.7 && < 3.14
   else
     build-depends: Cabal        >= 2.2.0.1 && < 3.7,
                    Cabal-syntax <  3.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -85,7 +85,7 @@ executable hackage-repo-tool
     build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.12
+    build-depends: Cabal-syntax >= 3.7 && < 3.14
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -136,7 +136,7 @@ library
     build-depends:     base       >= 4.11
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.12
+    build-depends: Cabal-syntax >= 3.7 && < 3.14
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,
@@ -240,8 +240,8 @@ test-suite TestSuite
                        zlib
 
   if flag(Cabal-syntax)
-    build-depends: Cabal        >= 3.7 && < 3.12,
-                   Cabal-syntax >= 3.7 && < 3.12
+    build-depends: Cabal        >= 3.7 && < 3.14,
+                   Cabal-syntax >= 3.7 && < 3.14
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,


### PR DESCRIPTION
I have tested the change by building `all` against `Cabal` and `Cabal-syntax` 3.12.