### PR TITLE
Release hackage-security-0.6.2.5

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.6.4

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.8.1', '9.6.4', '9.4.8']
+        ghc: ['9.8', '9.6', '9.4']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
@@ -24,24 +24,31 @@ jobs:
       id:   setup
       with:
         ghc-version:   ${{ matrix.ghc }}
-        # cabal-version: '3.8.1.0'
+        # cabal-version: latest
         cabal-update:  true
 
-    - name: Cache
-      uses: actions/cache@v4
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      id: cache
       env:
-        cache-name: haskell.yml
+        key: ${{ runner.os }}-cabal-${{ steps.setup.outputs.cabal-version }}-ghc-${{ steps.setup.outputs.ghc-version }}
       with:
         path: ${{ steps.setup.outputs.cabal-store }}
-        key:          ${{ runner.os }}-${{ env.cache-name }}-ghc-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
-        restore-keys: ${{ runner.os }}-${{ env.cache-name }}-ghc-${{ matrix.ghc }}-
+        key:          ${{ env.key }}-${{ github.sha }}
+        restore-keys: ${{ env.key }}-
 
     - name: Install dependencies
-      run: |
-        cabal build --only-dependencies --enable-tests --enable-benchmarks -vnormal+nowrap all
+      run: cabal build --only-dependencies --enable-tests --enable-benchmarks -vnormal+nowrap all
 
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks -j1 -vnormal+nowrap all
 
     - name: Run tests
       run: cabal test -j1 -vnormal+nowrap all
+
+    - name: Cache dependencies
+      uses: actions/cache/save@v4
+      if:   always()
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key:  ${{ steps.cache.outputs.cache-primary-key }}

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -23,7 +23,7 @@ homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -18,7 +18,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 extra-source-files:  ChangeLog.md
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,10 +1,17 @@
 See also http://pvp.haskell.org/faq
 
-Unreleased
-----------
+0.6.2.5
+-------
 
-* Drop support for GHC 7.
-* Drop flag `use-old-time` and support for `old-time`, require `time ≥ 1.5`.
+* Allow `Cabal-3.12` and `Cabal-syntax-3.12`.
+* Allow `zlib-0.7`.
+* Drop flag `use-old-time` and support for `old-time`, require `time ≥ 1.5`
+  ([PR #304](https://github.com/haskell/hackage-security/pull/304)).
+* Drop support for GHC < 8.4
+  ([PR #306](https://github.com/haskell/hackage-security/pull/306)).
+* Code maintenance: address warning `star-is-type`, `unused-record-wildcards` etc.
+  ([PR #306](https://github.com/haskell/hackage-security/pull/306)).
+* Tested with GHC 8.4 - 9.8.
 
 0.6.2.4
 -------

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                hackage-security
-version:             0.6.2.4
+version:             0.6.2.5
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -31,7 +31,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -15,7 +15,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.8.1
+  GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
   GHC == 9.2.8


### PR DESCRIPTION
- **Bump CI to GHC 9.8.2**
- ~~Allow `time < 1.15`.~~
- **Bump hackage-security to 0.6.2.5 and Changelog**

Candidate: https://hackage.haskell.org/package/hackage-security-0.6.2.5/candidate