### PR TITLE
Drop flag `use-network-uri` and support for `network-2.5`.

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -22,10 +22,6 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.4.4
 
-flag use-network-uri
-  description: Are we using network-uri?
-  manual: False
-
 flag Cabal-syntax
   description: Are we using Cabal-syntax?
   manual: False
@@ -39,6 +35,8 @@ executable example-client
                        bytestring           >= 0.10.8.2,
                        directory            >= 1.3.1.5,
                        filepath             >= 1.4.2,
+                       network-uri          >= 2.6,
+                       network              >= 2.6,
                        optparse-applicative >= 0.13,
                        time                 >= 1.8.0.2,
                        hackage-security     >= 0.5,
@@ -54,13 +52,6 @@ executable example-client
                        ScopedTypeVariables
   other-extensions:    CPP
   ghc-options:         -Wall
-
-  -- see comments in hackage-security.cabal
-  if flag(use-network-uri)
-    build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.2
-  else
-    build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
     build-depends: Cabal-syntax >= 3.7 && < 3.14

--- a/hackage-repo-tool/ChangeLog.md
+++ b/hackage-repo-tool/ChangeLog.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
-* Drop support for GHC 7.
+
+* Drop support for GHC < 8.4.
+* Drop flag `use-network-uri` and support for `network-2.5`.
 
 0.1.1.3
 -------

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -40,10 +40,6 @@ source-repository head
   type: git
   location: https://github.com/haskell/hackage-security.git
 
-flag use-network-uri
-  description: Are we using @network-uri@?
-  manual: False
-
 flag Cabal-syntax
   description: Are we using Cabal-syntax?
   manual: False
@@ -64,6 +60,8 @@ executable hackage-repo-tool
                        bytestring           >= 0.10.8.2 && < 0.13,
                        directory            >= 1.3.1.5  && < 1.4,
                        filepath             >= 1.4.2    && < 1.5,
+                       network-uri          >= 2.6      && < 2.7,
+                       network              >= 2.6      && < 3.2,
                        time                 >= 1.8.0.2  && < 1.13
   if !os(windows)
     build-depends:     unix                 >= 2.7.2.2  && < 2.9
@@ -75,14 +73,6 @@ executable hackage-repo-tool
                        tar                  >= 0.5      && < 0.7,
                        zlib                 >= 0.6      && < 0.8,
                        hackage-security     >= 0.6      && < 0.7
-
-  -- see comments in hackage-security.cabal
-  if flag(use-network-uri)
-    build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.9
-                            || >= 3.0 && < 3.2
-  else
-    build-depends: network     >= 2.5 && < 2.6
 
   if flag(Cabal-syntax)
     build-depends: Cabal-syntax >= 3.7 && < 3.14

--- a/hackage-security-HTTP/ChangeLog.md
+++ b/hackage-security-HTTP/ChangeLog.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
-* Drop support for GHC 7.
+
+* Drop support for GHC < 8.4.
+* Drop flag `use-network-uri` and support for `network-2.5`.
 
 
 0.1.1.1

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -35,16 +35,14 @@ source-repository head
   type: git
   location: https://github.com/haskell/hackage-security.git
 
-flag use-network-uri
-  description: Are we using network-uri?
-  manual: False
-
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
   build-depends:       base             >= 4.11      && < 4.20,
                        bytestring       >= 0.10.8.2  && < 0.13,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.2.2     && < 2.4,
+                       network-uri      >= 2.6       && < 2.7,
+                       network          >= 2.6       && < 3.2,
                        zlib             >= 0.5       && < 0.8,
                        hackage-security >= 0.5       && < 0.7
   hs-source-dirs:      src
@@ -57,11 +55,3 @@ library
                        StandaloneDeriving
   other-extensions:    CPP
   ghc-options:         -Wall
-
-  -- See comments in hackage-security.cabal
-  if flag(use-network-uri)
-    build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.9
-                            || >= 3.0 && < 3.2
-  else
-    build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -26,23 +26,14 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.4.4
 
-flag use-network-uri
-  description: Are we using network-uri?
-  manual: False
-
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
   build-depends:       base             >= 4.11     && < 4.20,
                        bytestring       >= 0.10.8.2 && < 0.13,
+                       network-uri      >= 2.6      && < 2.7,
+                       network          >= 2.6      && < 3.2,
                        process          >= 1.6.3    && < 1.7,
                        hackage-security >= 0.6.2    && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
-
-  -- See comments in hackage-security.cabal
-  if flag(use-network-uri)
-    build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.2
-  else
-    build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security-http-client/ChangeLog.md
+++ b/hackage-security-http-client/ChangeLog.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
-* Drop support for GHC 7.
+
+* Drop support for GHC < 8.4.
+* Drop flag `use-network-uri` and support for `network-2.5`.
+
 
 0.1.1
 -----

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -26,17 +26,15 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.4.4
 
-flag use-network-uri
-  description: Are we using network-uri?
-  manual: False
-
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
   build-depends:       base               >= 4.11     && < 4.20,
                        bytestring         >= 0.10.8.2 && < 0.13,
                        http-client        >= 0.4      && < 0.8,
                        http-types         >= 0.12.4   && < 0.13,
-                       hackage-security   >= 0.5      && < 0.7
+                       hackage-security   >= 0.5      && < 0.7,
+                       network-uri        >= 2.6      && < 2.7,
+                       network            >= 2.6      && < 3.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  FlexibleContexts
@@ -44,10 +42,3 @@ library
                        ScopedTypeVariables
   other-extensions:    OverloadedStrings
   ghc-options:         -Wall
-
-  -- see comments in hackage-security.cabal
-  if flag(use-network-uri)
-    build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 3.2
-  else
-    build-depends: network     >= 2.5 && < 2.6

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,5 +1,11 @@
 See also http://pvp.haskell.org/faq
 
+Unreleased
+----------
+
+* Drop flag `use-network-uri` and support for `network-2.5`.
+
+
 0.6.2.5
 -------
 

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -48,10 +48,6 @@ source-repository head
   type: git
   location: https://github.com/haskell/hackage-security.git
 
-flag use-network-uri
-  description: Are we using @network-uri@?
-  manual: False
-
 flag Cabal-syntax
   description: Are we using Cabal-syntax?
   manual: False
@@ -118,6 +114,8 @@ library
                        ed25519           >= 0.0      && < 0.1,
                        filepath          >= 1.4.2    && < 1.5,
                        mtl               >= 2.2.2    && < 2.4,
+                       network-uri       >= 2.6      && < 2.7,
+                       network           >= 2.6      && < 3.2,
                        parsec            >= 3.1.13   && < 3.2,
                        pretty            >= 1.0      && < 1.2,
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
@@ -126,7 +124,7 @@ library
                        template-haskell  >= 2.13     && < 2.22,
                        time              >= 1.8.0.2  && < 1.13,
                        transformers      >= 0.3      && < 0.7,
-                       zlib              >= 0.5     && < 0.8,
+                       zlib              >= 0.5      && < 0.8,
                        -- whatever versions are bundled with ghc:
                        ghc-prim          >= 0.5.2    && < 0.12
 
@@ -177,45 +175,6 @@ library
                        UndecidableInstances
 
   ghc-options:         -Wall
-
-  -- The URI type got split out off the network package after version 2.5, and
-  -- moved to a separate network-uri package. Since we don't need the rest of
-  -- network here, it would suffice to rely only on network-uri:
-  --
-  -- > if flag(use-network-uri)
-  -- >   build-depends: network-uri >= 2.6 && < 2.7
-  -- > else
-  -- >   build-depends: network     >= 2.5 && < 2.6
-  --
-  -- However, if we did the same in hackage-security-HTTP, Cabal would consider
-  -- those two flag choices (hackage-security:use-network-uri and
-  -- hackage-security-HTTP:use-network-uri) to be completely independent; but
-  -- they aren't: if it links hackage-security against network-uri and
-  -- hackage-security-HTTP against network, we will get type errors when
-  -- hackage-security-HTTP tries to pass a URI to hackage-security.
-  --
-  -- It might seem we can solve this problem by re-exporting the URI type in
-  -- hackage-security and avoid the dependency in hackage-security-HTTP
-  -- altogether. However, this merely shifts the problem: hackage-security-HTTP
-  -- relies on the HTTP library which--surprise!--makes the same choice between
-  -- depending on network or network-uri. Cabal will not notice that we cannot
-  -- build hackage-security and hackage-security-HTTP against network-uri but
-  -- HTTP against network.
-  --
-  -- We solve the problem by explicitly relying on network-2.6 when choosing
-  -- network-uri. This dependency is redundant, strictly speaking. However, it
-  -- serves as a proxy for forcing flag choices: since all packages in a
-  -- solution must be linked against the same version of network, having one
-  -- version of network in one branch of the conditional and another version of
-  -- network in the other branch forces the choice to be consistent throughout.
-  -- (Note that the HTTP library does the same thing, though in this case the
-  -- dependency in network is not redundant.)
-  if flag(use-network-uri)
-    build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.9
-                            || >= 3.0 && < 3.2
-  else
-    build-depends: network     >= 2.5 && < 2.6
 
 test-suite TestSuite
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
I realised (a bit too late for hackage-security-0.6.2.5) that since we dropped GHC < 8.4 we can also drop network-2.5.