### PR TITLE
Fix test compatibility with tar 0.5.*

### DIFF
--- a/hackage-security/tests/TestSuite.hs
+++ b/hackage-security/tests/TestSuite.hs
@@ -264,7 +264,11 @@ testRepoIndex inMemRepo repo = do
              _        -> fail "unexpected index entry content"
          _ -> fail "unexpected index path"
 
+#if MIN_VERSION_tar(0,6,0)
     testEntries1 :: [Tar.GenEntry Tar.TarPath linkTarget]
+#else
+    testEntries1 :: [Tar.Entry]
+#endif
     testEntries1 = either (const []) (pure . (`Tar.fileEntry` testEntrycontent))
         (Tar.toTarPath False "foo/preferred-versions")
     testEntrycontent   = BS.pack "foo >= 1"


### PR DESCRIPTION
The `GenEntry` method was added in tar-0.6.0.0 and thus building hackage-security with tar 0.5.* fails with the following errors:

```
[8 of 8] Compiling Main             ( tests/TestSuite.hs, dist/build/TestSuite/TestSuite-tmp/Main.dyn_o )

tests/TestSuite.hs:267:22: error:
    Not in scope: type constructor or class ‘Tar.GenEntry’
    Perhaps you meant ‘Tar.Entry’ (imported from Codec.Archive.Tar.Entry)
    Module ‘Codec.Archive.Tar.Entry’ does not export ‘GenEntry’.
    |
267 |     testEntries1 :: [Tar.GenEntry Tar.TarPath linkTarget]
    |                      ^^^^^^^^^^^^
```