### PR TITLE
Bump base, containers, filepath, network, time, zlib, CI for GHC 9.10

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.18.1.20240316
+# version: 0.19.20240403
 #
-# REGENDATA ("0.18.1.20240316",["github","cabal.project"])
+# REGENDATA ("0.19.20240403",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.0.20240328
+            compilerKind: ghc
+            compilerVersion: 9.10.0.20240328
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.2
             compilerKind: ghc
             compilerVersion: 9.8.2
@@ -88,7 +93,7 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.1 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -106,12 +111,12 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -140,6 +145,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -235,6 +252,9 @@ jobs:
           constraints: base-compat >= 0.12.2
           allow-newer: containers
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(example-client|hackage-repo-tool|hackage-root-tool|hackage-security|hackage-security-HTTP|hackage-security-curl|hackage-security-http-client|precompute-fileinfo)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -12,6 +12,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -31,7 +32,7 @@ executable example-client
   main-is:             Main.hs
   other-modules:       ExampleClient.Options
 
-  build-depends:       base                 >= 4.11 && < 4.20,
+  build-depends:       base                 >= 4.11 && < 4.21,
                        bytestring           >= 0.10.8.2,
                        directory            >= 1.3.1.5,
                        filepath             >= 1.4.2,

--- a/hackage-repo-tool/ChangeLog.md
+++ b/hackage-repo-tool/ChangeLog.md
@@ -1,6 +1,5 @@
-Unreleased
-----------
-
+0.1.1.4
+-------
 * Drop support for GHC < 8.4.
 * Drop flag `use-network-uri` and support for `network-2.5`.
 

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -23,6 +23,7 @@ homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -56,13 +57,13 @@ executable hackage-repo-tool
 
   -- For boot libraries we try to accomodate the versions bundled with
   -- the respective GHC release
-  build-depends:       base                 >= 4.11     && < 4.20,
+  build-depends:       base                 >= 4.11     && < 4.21,
                        bytestring           >= 0.10.8.2 && < 0.13,
                        directory            >= 1.3.1.5  && < 1.4,
-                       filepath             >= 1.4.2    && < 1.5,
+                       filepath             >= 1.4.2    && < 1.6,
                        network-uri          >= 2.6      && < 2.7,
-                       network              >= 2.6      && < 3.2,
-                       time                 >= 1.8.0.2  && < 1.13
+                       network              >= 2.6      && < 3.3,
+                       time                 >= 1.8.0.2  && < 1.15
   if !os(windows)
     build-depends:     unix                 >= 2.7.2.2  && < 2.9
 

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
-version:             0.1.1.3
+version:             0.1.1.4
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -16,6 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -37,7 +38,7 @@ source-repository head
 executable hackage-root-tool
   main-is:             Main.hs
   build-depends:       base                 >= 4.11  && < 5,
-                       filepath             >= 1.4.2 && < 1.5,
+                       filepath             >= 1.4.2 && < 1.6,
                        optparse-applicative >= 0.13  && < 0.19,
                        hackage-security     >= 0.5   && < 0.7
   default-language:    Haskell2010

--- a/hackage-security-HTTP/ChangeLog.md
+++ b/hackage-security-HTTP/ChangeLog.md
@@ -1,9 +1,7 @@
-Unreleased
-----------
-
+0.1.1.2
+-------
 * Drop support for GHC < 8.4.
 * Drop flag `use-network-uri` and support for `network-2.5`.
-
 
 0.1.1.1
 -------

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                hackage-security-HTTP
-version:             0.1.1.1
+version:             0.1.1.2
 
 synopsis:            Hackage security bindings against the HTTP library
 description:         The hackage security library provides a 'HttpLib'

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -18,6 +18,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -37,12 +38,12 @@ source-repository head
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
-  build-depends:       base             >= 4.11      && < 4.20,
+  build-depends:       base             >= 4.11      && < 4.21,
                        bytestring       >= 0.10.8.2  && < 0.13,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.2.2     && < 2.4,
                        network-uri      >= 2.6       && < 2.7,
-                       network          >= 2.6       && < 3.2,
+                       network          >= 2.6       && < 3.3,
                        zlib             >= 0.5       && < 0.8,
                        hackage-security >= 0.5       && < 0.7
   hs-source-dirs:      src

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -16,6 +16,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -28,10 +29,10 @@ tested-with:
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
-  build-depends:       base             >= 4.11     && < 4.20,
+  build-depends:       base             >= 4.11     && < 4.21,
                        bytestring       >= 0.10.8.2 && < 0.13,
                        network-uri      >= 2.6      && < 2.7,
-                       network          >= 2.6      && < 3.2,
+                       network          >= 2.6      && < 3.3,
                        process          >= 1.6.3    && < 1.7,
                        hackage-security >= 0.6.2    && < 0.7
   hs-source-dirs:      src

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -16,6 +16,7 @@ cabal-version:       >=1.10
 extra-source-files:  ChangeLog.md
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -28,14 +29,14 @@ tested-with:
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
-  build-depends:       base               >= 4.11     && < 4.20,
+  build-depends:       base               >= 4.11     && < 4.21,
                        bytestring         >= 0.10.8.2 && < 0.13,
                        http-client        >= 0.4      && < 0.8,
                        http-types         >= 0.12.2   && < 0.13,
                          -- http-types-0.12.2 is the version in Stackage LTS-12.26 (GHC 8.4)
                        hackage-security   >= 0.5      && < 0.7,
                        network-uri        >= 2.6      && < 2.7,
-                       network            >= 2.6      && < 3.2
+                       network            >= 2.6      && < 3.3
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  FlexibleContexts

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -31,6 +31,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -104,7 +105,7 @@ library
                        Hackage.Security.Util.Stack
                        Hackage.Security.Util.TypedEmbedded
 
-  build-depends:       base              >= 4.11     && < 4.20,
+  build-depends:       base              >= 4.11     && < 4.21,
                        base16-bytestring >= 0.1.1    && < 1.1,
                        base64-bytestring >= 1.0      && < 1.3,
                        bytestring        >= 0.10.8.2 && < 0.13,
@@ -112,17 +113,17 @@ library
                        cryptohash-sha256 >= 0.11     && < 0.12,
                        directory         >= 1.3.1.5  && < 1.4,
                        ed25519           >= 0.0      && < 0.1,
-                       filepath          >= 1.4.2    && < 1.5,
+                       filepath          >= 1.4.2    && < 1.6,
                        mtl               >= 2.2.2    && < 2.4,
                        network-uri       >= 2.6      && < 2.7,
-                       network           >= 2.6      && < 3.2,
+                       network           >= 2.6      && < 3.3,
                        parsec            >= 3.1.13   && < 3.2,
                        pretty            >= 1.0      && < 1.2,
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
                        -- functionality, 0.5.0 changes type of serialise
                        tar               >= 0.5      && < 0.7,
                        template-haskell  >= 2.13     && < 2.22,
-                       time              >= 1.8.0.2  && < 1.13,
+                       time              >= 1.8.0.2  && < 1.15,
                        transformers      >= 0.3      && < 0.7,
                        zlib              >= 0.5      && < 0.8,
                        -- whatever versions are bundled with ghc:

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -15,6 +15,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.10.0
   GHC == 9.8.2
   GHC == 9.6.4
   GHC == 9.4.8
@@ -27,16 +28,16 @@ tested-with:
 
 executable precompute-fileinfo
   main-is:             Main.hs
-  build-depends:       base                 >= 4.11     && < 4.20,
+  build-depends:       base                 >= 4.11     && < 4.21,
                        bytestring           >= 0.10.8.2 && < 0.13,
-                       containers           >= 0.5.11   && < 0.7,
+                       containers           >= 0.5.11   && < 0.8,
                        deepseq              >= 1.4.3    && < 1.6,
-                       filepath             >= 1.4.2    && < 1.5,
+                       filepath             >= 1.4.2    && < 1.6,
                        optparse-applicative >= 0.13     && < 0.19,
                        SHA                  >= 1.6.4    && < 1.7,
                        tar                  >= 0.5.0.2  && < 0.7,
                          -- tar-0.5.0.2 is the version in Stackage LTS-12.26 (GHC 8.4)
-                       zlib                 >= 0.6.2    && < 0.7
+                       zlib                 >= 0.6.2    && < 0.8
                          -- zlib-0.6.2 is the version in Stackage LTS-12.26 (GHC 8.4)
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
I tested building with `network-3.2.0.0` locally.