### PR TITLE
tasty quickcheck

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -25,7 +25,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -20,7 +20,7 @@ build-type:          Simple
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -18,7 +18,7 @@ extra-source-files:  ChangeLog.md
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -33,7 +33,7 @@ build-type:          Simple
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.6
+x-revision:          3
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -208,15 +209,15 @@ test-suite TestSuite
                    Cabal-syntax <  3.7
 
   -- dependencies exclusive to test-suite
-  build-depends:       tasty            >= 1.1.0.4 && < 1.6,
+  build-depends:       tasty                 >= 1.1.0.4  && < 1.6,
                          -- tasty-1.1.0.4 is the version in Stackage LTS 12.26 (GHC 8.4)
-                       tasty-hunit      == 0.10.*,
-                       tasty-quickcheck == 0.10.*,
-                       QuickCheck       >= 2.11 && <2.15,
-                       aeson            >= 1.4 && < 1.6 || >= 2.0 && < 2.3,
-                       vector           >= 0.12 && <0.14,
-                       unordered-containers >=0.2.8.0 && <0.3,
-                       temporary        >= 1.2 && < 1.4
+                       tasty-hunit           == 0.10.*,
+                       tasty-quickcheck      >= 0.10     && < 1,
+                       QuickCheck            >= 2.11     && < 2.16,
+                       aeson                 >= 1.4      && < 1.6 || >= 2.0 && < 2.3,
+                       vector                >= 0.12     && < 0.14,
+                       unordered-containers  >= 0.2.8.0  && < 0.3,
+                       temporary             >= 1.2      && < 1.4
 
   hs-source-dirs:      tests
   default-language:    Haskell2010

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 tested-with:
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2


### PR DESCRIPTION
- **Bump CI to GHC 9.6.5**
- **hackage-security/v0.6.2.6-r3: allow newer QuickCheck and tasty-quickcheck**

See:
- https://github.com/commercialhaskell/stackage/issues/7460
