### PR TITLE
Bump Cabal and Cabal-syntax to allow 3.14

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -55,7 +55,7 @@ executable example-client
   ghc-options:         -Wall
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.14
+    build-depends: Cabal-syntax >= 3.7 && < 3.16
   else
     build-depends: Cabal        >= 2.2.0.1 && < 3.7,
                    Cabal-syntax <  3.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -75,7 +75,7 @@ executable hackage-repo-tool
                        hackage-security     >= 0.6      && < 0.7
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.14
+    build-depends: Cabal-syntax >= 3.7 && < 3.16
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -136,7 +136,7 @@ library
     build-depends:     base       >= 4.11
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.14
+    build-depends: Cabal-syntax >= 3.7 && < 3.16
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,
@@ -201,8 +201,8 @@ test-suite TestSuite
                        zlib
 
   if flag(Cabal-syntax)
-    build-depends: Cabal        >= 3.7 && < 3.14,
-                   Cabal-syntax >= 3.7 && < 3.14
+    build-depends: Cabal        >= 3.7 && < 3.16,
+                   Cabal-syntax >= 3.7 && < 3.16
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,


### PR DESCRIPTION
I have tested the change by running `cabal build all && cabal test all` with the following cabal.project.local:

    packages: /path-to-cabal-repo/Cabal
    packages: /path-to-cabal-repo/Cabal-syntax
    constraints: Cabal==3.14.*
    constraints: Cabal-syntax==3.14.*

where /path-to-cabal-repo is my local checkout of cabal 3.14