### PR TITLE
ghc 9.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240517
+# version: 0.19.20241223
 #
-# REGENDATA ("0.19.20240517",["github","cabal.project"])
+# REGENDATA ("0.19.20241223",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.1
+            compilerKind: ghc
+            compilerVersion: 9.12.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -42,9 +47,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.6.6
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -84,15 +89,29 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -103,21 +122,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -299,8 +309,8 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ubuntu-latest]
-        ghc: ['9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4']
+        ghc: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4']
         include:
           - os: macos-latest
-            ghc: '9.8'
+            ghc: '9.10'
           - os: windows-latest
-            ghc: '9.8'
+            ghc: '9.10'
 
     steps:
     - uses: actions/checkout@v4

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -12,9 +12,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -32,7 +33,7 @@ executable example-client
   main-is:             Main.hs
   other-modules:       ExampleClient.Options
 
-  build-depends:       base                 >= 4.11 && < 4.21,
+  build-depends:       base                 >= 4.11 && < 4.22,
                        bytestring           >= 0.10.8.2,
                        directory            >= 1.3.1.5,
                        filepath             >= 1.4.2,

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.12
 name:                hackage-repo-tool
 version:             0.1.1.4
+x-revision:          1
 
 build-type:          Simple
 synopsis:            Manage secure file-based package repositories
@@ -23,9 +24,10 @@ homepage:            https://github.com/haskell/hackage-security
 bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -57,7 +59,7 @@ executable hackage-repo-tool
 
   -- For boot libraries we try to accomodate the versions bundled with
   -- the respective GHC release
-  build-depends:       base                 >= 4.11     && < 4.21,
+  build-depends:       base                 >= 4.11     && < 4.22,
                        bytestring           >= 0.10.8.2 && < 0.13,
                        directory            >= 1.3.1.5  && < 1.4,
                        filepath             >= 1.4.2    && < 1.6,

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -16,9 +16,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security-HTTP
 version:             0.1.1.2
+x-revision:          1
 
 synopsis:            Hackage security bindings against the HTTP library
 description:         The hackage security library provides a 'HttpLib'
@@ -18,9 +19,10 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -38,7 +40,7 @@ source-repository head
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HTTP
-  build-depends:       base             >= 4.11      && < 4.21,
+  build-depends:       base             >= 4.11      && < 4.22,
                        bytestring       >= 0.10.8.2  && < 0.13,
                        HTTP             >= 4000.2.19 && < 4000.5,
                        mtl              >= 2.2.2     && < 2.4,

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -16,9 +16,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -29,7 +30,7 @@ tested-with:
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.Curl
-  build-depends:       base             >= 4.11     && < 4.21,
+  build-depends:       base             >= 4.11     && < 4.22,
                        bytestring       >= 0.10.8.2 && < 0.13,
                        network-uri      >= 2.6      && < 2.7,
                        network          >= 2.6      && < 3.3,

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -16,9 +16,10 @@ cabal-version:       >=1.10
 extra-source-files:  ChangeLog.md
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -29,7 +30,7 @@ tested-with:
 
 library
   exposed-modules:     Hackage.Security.Client.Repository.HttpLib.HttpClient
-  build-depends:       base               >= 4.11     && < 4.21,
+  build-depends:       base               >= 4.11     && < 4.22,
                        bytestring         >= 0.10.8.2 && < 0.13,
                        http-client        >= 0.4      && < 0.8,
                        http-types         >= 0.12.2   && < 0.13,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                hackage-security
 version:             0.6.2.6
-x-revision:          4
+x-revision:          5
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -32,9 +32,10 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 build-type:          Simple
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -106,7 +107,7 @@ library
                        Hackage.Security.Util.Stack
                        Hackage.Security.Util.TypedEmbedded
 
-  build-depends:       base              >= 4.11     && < 4.21,
+  build-depends:       base              >= 4.11     && < 4.22,
                        base16-bytestring >= 0.1.1    && < 1.1,
                        base64-bytestring >= 1.0      && < 1.3,
                        bytestring        >= 0.10.8.2 && < 0.13,
@@ -123,12 +124,12 @@ library
                        -- 0.4.2 introduces TarIndex, 0.4.4 introduces more
                        -- functionality, 0.5.0 changes type of serialise
                        tar               >= 0.5      && < 0.7,
-                       template-haskell  >= 2.13     && < 2.23,
+                       template-haskell  >= 2.13     && < 2.24,
                        time              >= 1.8.0.2  && < 1.15,
                        transformers      >= 0.3      && < 0.7,
                        zlib              >= 0.5      && < 0.8,
                        -- whatever versions are bundled with ghc:
-                       ghc-prim          >= 0.5.2    && < 0.12
+                       ghc-prim          >= 0.5.2    && < 0.14
 
   if flag(lukko)
     build-depends:     lukko      >= 0.1     && < 0.2

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -15,9 +15,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -28,7 +29,7 @@ tested-with:
 
 executable precompute-fileinfo
   main-is:             Main.hs
-  build-depends:       base                 >= 4.11     && < 4.21,
+  build-depends:       base                 >= 4.11     && < 4.22,
                        bytestring           >= 0.10.8.2 && < 0.13,
                        containers           >= 0.5.11   && < 0.8,
                        deepseq              >= 1.4.3    && < 1.6,

--- a/stack-9.10.yaml
+++ b/stack-9.10.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.3
+resolver: nightly-2025-01-05
 packages:
 - example-client
 - hackage-repo-tool

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.15
+resolver: lts-22.43
 packages:
 - example-client
 - hackage-repo-tool


### PR DESCRIPTION
- **Bump Stack CI**
- **Revisions for GHC 9.12**

Tested with GHC 9.12 locally:
```
$ cabal test all -w ghc-9.12.1 --allow-newer=lukko:base --allow-newer=these:base --allow-newer=aeson:* -c 'aeson >=2.2' --allow-newer=HTTP:base
```

Blockers for CI:
- [ ] https://github.com/haskell/aeson/issues/1124
- [x] https://github.com/haskellari/lukko/issues/39

Published revisions:

2025-01-05T16:21:52Z  	AndreasAbel	  [hackage-security-HTTP-0.1.1.2-r1](https://hackage.haskell.org/package/hackage-security-HTTP-0.1.1.2/revisions)
2025-01-05T16:21:51Z  	AndreasAbel	  [hackage-repo-tool-0.1.1.4-r1](https://hackage.haskell.org/package/hackage-repo-tool-0.1.1.4/revisions)
2025-01-05T16:21:50Z  	AndreasAbel	  [hackage-security-0.6.2.6-r5](https://hackage.haskell.org/package/hackage-security-0.6.2.6/revisions)