### PR TITLE
Bump version to 0.6.3.0 and update changelog

### DIFF
--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,5 +1,18 @@
 See also http://pvp.haskell.org/faq
 
+0.6.3.0
+-------
+
+* Make `lukko` flag automatic and off by default, using file locking
+  facilities from `GHC.IO.Handle.Lock` and not from
+  on [`lukko` package](https://hackage.haskell.org/package/lukko).
+  The change is not expected to affect anyone detrimentally,
+  but one can set the flag on in their configuration to restore
+  the previous behaviour.
+* Allow building against newer releases of dependencies.
+* Tested with GHC 8.4 - 9.12.
+
+
 0.6.2.6
 -------
 

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,7 +1,6 @@
 cabal-version:       1.12
 name:                hackage-security
-version:             0.6.2.6
-x-revision:          5
+version:             0.6.3.0
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and


### PR DESCRIPTION
Let's release changes to `lukko`.

Technically it could be 0.6.2.7 (because it's only metadata changes), but to be extra safe and allow people to use `#if MIN_VERSION_hackage_security(0,6,3)`, let's make it 0.6.3.0.