### PR TITLE
bump QuickCheck

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250330
+# version: 0.19.20250506
 #
-# REGENDATA ("0.19.20250330",["github","cabal.project"])
+# REGENDATA ("0.19.20250506",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -37,9 +37,9 @@ jobs:
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -100,8 +100,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -13,7 +13,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -25,7 +25,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -71,7 +71,7 @@ executable hackage-repo-tool
 
   build-depends:       microlens            >= 0.4.9.1  && < 0.5,
                          -- microlens-0.4.9.1 is the version in Stackage LTS-12.26 (GHC 8.4)
-                       optparse-applicative >= 0.13     && < 0.19,
+                       optparse-applicative >= 0.13     && < 0.20,
                        tar                  >= 0.5      && < 0.7,
                        zlib                 >= 0.6      && < 0.8,
                        hackage-security     >= 0.6      && < 0.7

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -40,7 +40,7 @@ executable hackage-root-tool
   main-is:             Main.hs
   build-depends:       base                 >= 4.11  && < 5,
                        filepath             >= 1.4.2 && < 1.6,
-                       optparse-applicative >= 0.13  && < 0.19,
+                       optparse-applicative >= 0.13  && < 0.20,
                        hackage-security     >= 0.5   && < 0.7
   default-language:    Haskell2010
   other-extensions:    CPP, ScopedTypeVariables, RecordWildCards

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -20,7 +20,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -17,7 +17,7 @@ extra-source-files:  ChangeLog.md
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -213,7 +213,7 @@ test-suite TestSuite
                          -- tasty-1.1.0.4 is the version in Stackage LTS 12.26 (GHC 8.4)
                        tasty-hunit           == 0.10.*,
                        tasty-quickcheck      >= 0.10     && < 1,
-                       QuickCheck            >= 2.11     && < 2.16,
+                       QuickCheck            >= 2.11     && < 2.17,
                        aeson                 >= 1.4      && < 1.6 || >= 2.0 && < 2.3,
                        vector                >= 0.12     && < 0.14,
                        unordered-containers  >= 0.2.8.0  && < 0.3,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -32,7 +32,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/hackage-security/tests/TestSuite.hs
+++ b/hackage-security/tests/TestSuite.hs
@@ -2,14 +2,14 @@
 module Main (main) where
 
 -- stdlib
-import Control.Exception
-import Control.Monad
+import Control.Exception ( handleJust )
+import Control.Monad ( unless )
 import Data.Maybe (fromJust)
-import Data.Time
-import Network.URI (URI, parseURI)
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck hiding (label)
+import Data.Time ( UTCTime, getCurrentTime )
+import Network.URI ( URI, parseURI )
+import Test.Tasty ( defaultMain, testGroup, TestTree )
+import Test.Tasty.HUnit ( testCase, (@?=), assertEqual, assertFailure, Assertion )
+import Test.Tasty.QuickCheck ( testProperty )
 import System.IO.Temp (withSystemTempDirectory)
 import qualified Codec.Archive.Tar.Entry    as Tar
 import qualified Data.ByteString.Lazy.Char8 as BS

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -34,7 +34,7 @@ executable precompute-fileinfo
                        containers           >= 0.5.11   && < 0.8,
                        deepseq              >= 1.4.3    && < 1.6,
                        filepath             >= 1.4.2    && < 1.6,
-                       optparse-applicative >= 0.13     && < 0.19,
+                       optparse-applicative >= 0.13     && < 0.20,
                        SHA                  >= 1.6.4    && < 1.7,
                        tar                  >= 0.5.0.2  && < 0.7,
                          -- tar-0.5.0.2 is the version in Stackage LTS-12.26 (GHC 8.4)


### PR DESCRIPTION
- **Bump Haskell CI for 9.10 to 9.10.2**
  

- **Bump optparse-applicative to <0.20**
  

- **Bump QuickCheck to <2.17**
  