### PR TITLE
update `Cabal-syntax` bound to permit 3.16

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -56,7 +56,7 @@ executable example-client
   ghc-options:         -Wall
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.16
+    build-depends: Cabal-syntax >= 3.7 && < 3.18
   else
     build-depends: Cabal        >= 2.2.0.1 && < 3.7,
                    Cabal-syntax <  3.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -77,7 +77,7 @@ executable hackage-repo-tool
                        hackage-security     >= 0.6      && < 0.7
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.16
+    build-depends: Cabal-syntax >= 3.7 && < 3.18
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -136,7 +136,7 @@ library
     build-depends:     base       >= 4.11
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.16
+    build-depends: Cabal-syntax >= 3.7 && < 3.18
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,
@@ -201,7 +201,7 @@ test-suite TestSuite
                        zlib
 
   if flag(Cabal-syntax)
-    build-depends: Cabal        >= 3.7 && < 3.16,
+    build-depends: Cabal        >= 3.7 && < 3.18,
                    Cabal-syntax >= 3.7 && < 3.16
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6


### PR DESCRIPTION
We're preparing to release `Cabal` and `Cabal-syntax` 3.16. As per https://github.com/haskell/hackage-security/pull/309 we need `hackage-security` to be updated before we release.