### PR TITLE
Allow QuickCheck-2.18

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20251211
+# version: 0.19.20260209
 #
-# REGENDATA ("0.19.20251211",["github","cabal.project"])
+# REGENDATA ("0.19.20260209",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,6 +23,8 @@ on:
   merge_group:
     branches:
       - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -35,14 +37,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.14.0.20251128
+          - compiler: ghc-9.14.1
             compilerKind: ghc
-            compilerVersion: 9.14.0.20251128
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.14.1
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.12.2
+          - compiler: ghc-9.12.4
             compilerKind: ghc
-            compilerVersion: 9.12.2
+            compilerVersion: 9.12.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.3
@@ -124,21 +126,6 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -149,7 +136,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -177,18 +164,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,7 +187,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -299,9 +274,6 @@ jobs:
           cat >> cabal.project <<EOF
           constraints: base-compat >= 0.12.2
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(example-client|hackage-repo-tool|hackage-root-tool|hackage-security|hackage-security-HTTP|hackage-security-curl|hackage-security-http-client|precompute-fileinfo)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -310,7 +282,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -364,7 +336,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all
       - name: save cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -13,7 +13,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -26,7 +26,7 @@ bug-reports:         https://github.com/haskell/hackage-security/issues
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hackage-security-HTTP/hackage-security-HTTP.cabal
+++ b/hackage-security-HTTP/hackage-security-HTTP.cabal
@@ -21,7 +21,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hackage-security-curl/hackage-security-curl.cabal
+++ b/hackage-security-curl/hackage-security-curl.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hackage-security-http-client/hackage-security-http-client.cabal
+++ b/hackage-security-http-client/hackage-security-http-client.cabal
@@ -17,7 +17,7 @@ extra-source-files:  ChangeLog.md
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -2,7 +2,7 @@ cabal-version:       1.18
 name:                hackage-security
 version:             0.6.3.2
 -- remove x-revision when you bump the version
-x-revision:          1
+x-revision:          2
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -216,7 +216,7 @@ test-suite TestSuite
                          -- tasty-1.1.0.4 is the version in Stackage LTS 12.26 (GHC 8.4)
                        tasty-hunit           == 0.10.*,
                        tasty-quickcheck      >= 0.10     && < 1,
-                       QuickCheck            >= 2.11     && < 2.18,
+                       QuickCheck            >= 2.11     && < 2.19,
                        aeson                 >= 1.4      && < 1.6 || >= 2.0 && < 2.3,
                        vector                >= 0.12     && < 0.14,
                        unordered-containers  >= 0.2.8.0  && < 0.3,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/precompute-fileinfo/precompute-fileinfo.cabal
+++ b/precompute-fileinfo/precompute-fileinfo.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7


### PR DESCRIPTION
See https://github.com/commercialhaskell/stackage/issues/7857

- **Bump Haskell CI for 9.12 to 9.12.4**
  

- **hackage-security v0.6.3.2 revision 2: allow QuickCheck-2.18**
  