### PR TITLE
Stop using lukko

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -328,12 +328,6 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
-      - name: constraint set no-lukko
-        run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all --dry-run
-          cabal-plan topo | sort
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' --dependencies-only -j2 all
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='hackage-security -lukko' all
       - name: save cache
         if: always()
         uses: actions/cache/save@v5

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -19,9 +19,6 @@ raw-project
   constraints:
     base-compat >= 0.12.2
 
-constraint-set no-lukko
-  constraints: hackage-security -lukko
-
 -- constraint-set containers-0.7
 --   -- Andreas, 2024-03-19: possibly we will have to turn off the constraint set
 --   -- for the head.hackage build with GHC 9.10.0

--- a/cabal.project
+++ b/cabal.project
@@ -11,5 +11,3 @@ packages: hackage-security
 
 package hackage-security
   tests: true
-
--- constraints: hackage-security -lukko

--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,5 +1,10 @@
 See also http://pvp.haskell.org/faq
 
+Unreleased
+-------
+* Remove `lukko` package flag. Now we unconditionally use `GHC.IO.Handle.Lock`
+  instead of the [`lukko` package](https://hackage.haskell.org/package/lukko).
+
 0.6.3.2
 -------
 

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -58,11 +58,6 @@ flag Cabal-syntax
   manual: False
   default: False
 
-flag lukko
-  description: Use @lukko@ for file-locking, otherwise use @GHC.IO.Handle.Lock@
-  manual:      False
-  default:     False
-
 library
   -- Most functionality is exported through the top-level entry points .Client
   -- and .Server; the other exported modules are intended for qualified imports.
@@ -132,11 +127,6 @@ library
                        zlib              >= 0.5      && < 0.8,
                        -- whatever versions are bundled with ghc:
                        ghc-prim          >= 0.5.2    && < 0.14
-
-  if flag(lukko)
-    build-depends:     lukko      >= 0.1     && < 0.2
-  else
-    build-depends:     base       >= 4.11
 
   if flag(Cabal-syntax)
     build-depends: Cabal-syntax >= 3.7 && < 3.18

--- a/hackage-security/src/Hackage/Security/Util/IO.hs
+++ b/hackage-security/src/Hackage/Security/Util/IO.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Hackage.Security.Util.IO (
     -- * Miscelleneous
     getFileSize
@@ -18,14 +17,7 @@ import System.IO.Error
 
 import Hackage.Security.Util.Path
 
-#ifdef MIN_VERSION_lukko
-import Lukko (FD, fileLockingSupported, fdOpen, fdClose, fdLock, fdUnlock, LockMode(ExclusiveLock))
-#else
-import GHC.IO.Handle.Lock (hLock, LockMode(ExclusiveLock), FileLockingNotSupported)
-#if MIN_VERSION_base(4,11,0)
-import GHC.IO.Handle.Lock (hUnlock)
-#endif
-#endif
+import GHC.IO.Handle.Lock (hLock, hUnlock, LockMode(ExclusiveLock), FileLockingNotSupported)
 
 {-------------------------------------------------------------------------------
   Miscelleneous
@@ -85,33 +77,6 @@ withDirLock logger dir
       logger (WithDirLockEventPost lock)
       return h
 
-#ifdef MIN_VERSION_lukko
-    takeLock :: IO FD
-    takeLock
-        | fileLockingSupported = do
-            h <- fdOpen lock'
-            wrapLog (fdLock h ExclusiveLock `onException` fdClose h)
-            return h
-        | otherwise = wrapLog takeDirLock
-      where
-        takeDirLock :: IO FD
-        takeDirLock = handle onCreateDirError $ do
-            createDirectory lock
-            return (undefined :: FD)
-
-        onCreateDirError :: IOError -> IO FD
-        onCreateDirError ioe
-          | isAlreadyExistsError ioe = threadDelay (1*1000*1000) >> takeDirLock
-          | otherwise = fail (me++"error creating directory lock: "++show ioe)
-
-    releaseLock h
-        | fileLockingSupported = do
-            fdUnlock h
-            fdClose h
-        | otherwise =
-            removeDirectory lock
-
-#else
     takeLock = do
         h <- openFile lock' ReadWriteMode
         wrapLog $ handle (fallbackToDirLock h) $ do
@@ -142,12 +107,9 @@ withDirLock logger dir
             (me++"cannot remove lock file before directory lock fallback")
 
     releaseLock (Just h) =
-#if MIN_VERSION_base(4,11,0)
         hUnlock h >>
-#endif
         hClose h
     releaseLock Nothing  = removeDirectory lock
-#endif
 
 {-------------------------------------------------------------------------------
   Debugging

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -16,12 +16,9 @@ flags:
     cabal-syntax: false
   hackage-security:
     cabal-syntax: false
-    lukko: false
-      # LTS 12 does not have lukko yet
 
 extra-deps:
 - Cabal-syntax-3.6.0.0
 - aeson-1.4.3.0
   ## aeson-1.4.3.0 is the newest that works with the other deps in LTS 12
   ## aeson-1.4.4.0 asks for time-compat >= 1.9.2.2
-# - lukko-0.1.1.3

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -16,9 +16,6 @@ flags:
     cabal-syntax: false
   hackage-security:
     cabal-syntax: false
-    lukko: false
-      # LTS 14 does not have lukko yet
 
 extra-deps:
 - Cabal-syntax-3.6.0.0
-# - lukko-0.1.1.3


### PR DESCRIPTION
A year ago we stopped using `lukko` package by default and guarded it by a Cabal flag. No one complained and I never heard of anyone forcing the Cabal flag to use `lukko` instead of `base`. I think it's time we clean it up entirely.