### PR TITLE
Update Cabal and Cabal-syntax bounds to permit cabal 3.18

### DIFF
--- a/example-client/example-client.cabal
+++ b/example-client/example-client.cabal
@@ -56,7 +56,7 @@ executable example-client
   ghc-options:         -Wall
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.18
+    build-depends: Cabal-syntax >= 3.7 && < 3.20
   else
     build-depends: Cabal        >= 2.2.0.1 && < 3.7,
                    Cabal-syntax <  3.7

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -80,7 +80,7 @@ executable hackage-repo-tool
                        hackage-security     >= 0.6      && < 0.7
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.18
+    build-depends: Cabal-syntax >= 3.7 && < 3.20
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -129,7 +129,7 @@ library
                        ghc-prim          >= 0.5.2    && < 0.14
 
   if flag(Cabal-syntax)
-    build-depends: Cabal-syntax >= 3.7 && < 3.18
+    build-depends: Cabal-syntax >= 3.7 && < 3.20
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,
@@ -194,8 +194,8 @@ test-suite TestSuite
                        zlib
 
   if flag(Cabal-syntax)
-    build-depends: Cabal        >= 3.7 && < 3.18,
-                   Cabal-syntax >= 3.7 && < 3.18
+    build-depends: Cabal        >= 3.7 && < 3.20,
+                   Cabal-syntax >= 3.7 && < 3.20
   else
     build-depends: Cabal        >= 2.2.0.1 && < 2.6
                              || >= 3.0     && < 3.7,


### PR DESCRIPTION
It would be good to release a new hackage-security version to Hackage once this PR is merged, to test cabal 3.18 with it before the cabal 3.18 release.

@andreasabel: would you like to do the release, as you did last time, or shall I?