### PR TITLE
Bump hackage-security to 0.6.3.3 and ChangeLog

### DIFF
--- a/hackage-security/ChangeLog.md
+++ b/hackage-security/ChangeLog.md
@@ -1,9 +1,13 @@
 See also http://pvp.haskell.org/faq
 
-Unreleased
+0.6.3.3
 -------
+
 * Remove `lukko` package flag. Now we unconditionally use `GHC.IO.Handle.Lock`
   instead of the [`lukko` package](https://hackage.haskell.org/package/lukko).
+* Allow `Cabal-3.18` and `Cabal-syntax-3.18`.
+* Allow building against newer releases of other dependencies.
+* Tested with GHC 8.4 - 9.14.
 
 0.6.3.2
 -------

--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,8 +1,6 @@
 cabal-version:       1.18
 name:                hackage-security
-version:             0.6.3.2
--- remove x-revision when you bump the version
-x-revision:          2
+version:             0.6.3.3
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and


### PR DESCRIPTION
This is in preparation of the cabal 3.18 release. I will release to Hackage right after this is merged. The other packages in this repo are not touched nor released at this time.