### PR TITLE
hackage-security 0.6.3.3 revision 1: allow aeson-2.3 in testsuite

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -1,6 +1,7 @@
 cabal-version:       1.18
 name:                hackage-security
 version:             0.6.3.3
+x-revision:          1
 
 synopsis:            Hackage security library
 description:         The hackage security library provides both server and
@@ -205,7 +206,7 @@ test-suite TestSuite
                        tasty-hunit           == 0.10.*,
                        tasty-quickcheck      >= 0.10     && < 1,
                        QuickCheck            >= 2.11     && < 2.19,
-                       aeson                 >= 1.4      && < 1.6 || >= 2.0 && < 2.3,
+                       aeson                 >= 1.4      && < 1.6 || >= 2.0 && < 2.4,
                        vector                >= 0.12     && < 0.14,
                        unordered-containers  >= 0.2.8.0  && < 0.3,
                        temporary             >= 1.2      && < 1.4


### PR DESCRIPTION
hackage-security 0.6.3.3 revision 1: allow aeson-2.3 in testsuite

See: 
- https://github.com/commercialhaskell/stackage/issues/8016

Revision published on hackage.